### PR TITLE
feat(telegram): add media message support for Telegram sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-04-07
+
+### Added
+
+- 新增订阅导入/批量退订辅助模块 `utils/command_helpers.py`，将筛选、导出、删除与导入应用逻辑从命令处理器中拆分，提升维护性
+- 新增 Telegram 媒体发送调试信息：记录 `video/audio` 最终来源（`url` 或 `local_path`）并输出哈希，便于排查线上媒体链路问题
+
+### Changed
+
+- 调整 Telegram 发送策略为媒体优先（media-first）：图片/视频/音频优先于文本进入消息链，并在分片回退路径中保持同样顺序
+- `RSSHubRadarAPI` 规则缓存改为带容量限制的 `LRU + TTL`（按 `base_url` 键），避免长期运行时缓存无界增长
+- `RSSHubRadarAPI` 网络请求/JSON 解析错误信息增强：增加 `base_url`、`url` 与异常类型上下文，提升故障定位效率
+- `/unsub_all` 行为明确为“默认当前会话，`global` 全局删除（管理员）”，并移除历史 `yes` 参数语义
+
+### Fixed
+
+- 修复 Telegram 媒体发送 `Wrong http url specified` 问题：在 Telegram 发送前将 `file:///` URI 归一化为本地路径，避免适配器侧误判 URL
+- 修复多处中文提示乱码（mojibake），包括路由参数获取失败、默认选项更新提示与测试推送目标提示
+- 修复 `AiocqhttpMessageSender` 在媒体回退为纯文本且发送成功时仍标记 `transient=True` 的问题，避免误触发重试逻辑
+- 修复导入会话键类型注解与实际值不一致问题，统一使用字符串 sender_id 构造会话键
+
+### Security
+
+- 限制本地路径导入能力：仅管理员可用，且仅允许读取插件数据目录白名单路径下文件，降低越权读取风险
+
+### Docs
+
+- 更新命令文档：`/sub_list [all]` 与实现保持一致；PR 模板与贡献文档文字表述修正并同步
+
 ## [1.0.2] - 2026-04-06
 
 ### Changed

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_rsshub
 display_name: RSS订阅插件
 desc: RSS 订阅插件，支持多平台消息推送。
-version: v1.0.2
+version: v1.0.3
 author: FlanChanXwO
 repo: https://github.com/FlanChanXwO/astrbot_plugin_rsshub

--- a/notifier/notifier.py
+++ b/notifier/notifier.py
@@ -191,10 +191,14 @@ class Notifier:
             logger.warning("订阅缺少推送目标: sub=%s, user=%s", sub.id, sub.user_id)
             return
 
-        sender = get_sender_for_platform_name(sub.platform_name)
+        sender_platform_name = (sub.platform_name or "").strip()
+        if not sender_platform_name and session_id:
+            sender_platform_name = session_id.split(":", 1)[0]
+
+        sender = get_sender_for_platform_name(sender_platform_name)
         logger.debug(
             "Push strategy selected: platform=%s, sender=%s, has_media=%s, prepared_media=%s, session=%s",
-            sub.platform_name,
+            sender_platform_name or sub.platform_name,
             sender.__name__,
             bool(media_items),
             bool(prepared_media),

--- a/notifier/senders/factory.py
+++ b/notifier/senders/factory.py
@@ -14,8 +14,14 @@ def get_sender_for_platform_name(platform_name: str | None) -> type[MessageSende
     Returns:
         对应的 MessageSender 子类，用于实现平台特定的发送策略
     """
-    if platform_name == "telegram":
+    normalized = (platform_name or "").strip().lower()
+
+    if normalized in {"telegram", "tg"} or "telegram" in normalized:
         return TelegramMessageSender
-    if platform_name == "aiocqhttp":
+
+    if normalized in {"aiocqhttp", "onebot", "onebot11", "onebotv11"}:
         return AiocqhttpMessageSender
+    if "aiocqhttp" in normalized or "onebot" in normalized:
+        return AiocqhttpMessageSender
+
     return MessageSender

--- a/notifier/senders/telegram.py
+++ b/notifier/senders/telegram.py
@@ -89,17 +89,22 @@ class TelegramMessageSender(MessageSender):
         return path
 
     @classmethod
+    def _normalize_component_file_value(cls, component: Image | Video | Record) -> None:
+        file_value = getattr(component, "file", None)
+        if isinstance(file_value, str):
+            component.file = cls._uri_to_local_path(file_value)
+
+    @classmethod
     def _normalize_components_for_telegram(
         cls,
-        image_components: list,
-        tail_components: list,
+        image_components: list[Image | Video | Record],
+        tail_components: list[Image | Video | Record],
     ) -> None:
-        for component in [*image_components, *tail_components]:
-            if not isinstance(component, (Image, Video, Record)):
-                continue
-            file_value = getattr(component, "file", None)
-            if isinstance(file_value, str) and file_value.startswith("file:///"):
-                component.file = cls._uri_to_local_path(file_value)
+        for component in image_components:
+            cls._normalize_component_file_value(component)
+
+        for component in tail_components:
+            cls._normalize_component_file_value(component)
 
     @classmethod
     async def send_to_user(

--- a/notifier/senders/telegram.py
+++ b/notifier/senders/telegram.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+from urllib.parse import unquote, urlsplit
 
 from astrbot.api import logger
-from astrbot.api.message_components import Plain
+from astrbot.api.message_components import Image, Plain, Record, Video
 
 from .base import MessageSender
 from .media_downloader import get_or_download_media_to_cache
@@ -75,6 +76,31 @@ class TelegramMessageSender(MessageSender):
                     cls._hash_for_log(item.original_url),
                 )
 
+    @staticmethod
+    def _uri_to_local_path(file_value: str) -> str:
+        if not file_value.startswith("file:///"):
+            return file_value
+
+        parsed = urlsplit(file_value)
+        path = unquote(parsed.path or "")
+        # On Windows, file:///C:/... is parsed as /C:/...
+        if len(path) >= 3 and path[0] == "/" and path[2] == ":":
+            return path[1:]
+        return path
+
+    @classmethod
+    def _normalize_components_for_telegram(
+        cls,
+        image_components: list,
+        tail_components: list,
+    ) -> None:
+        for component in [*image_components, *tail_components]:
+            if not isinstance(component, (Image, Video, Record)):
+                continue
+            file_value = getattr(component, "file", None)
+            if isinstance(file_value, str) and file_value.startswith("file:///"):
+                component.file = cls._uri_to_local_path(file_value)
+
     @classmethod
     async def send_to_user(
         cls,
@@ -110,6 +136,10 @@ class TelegramMessageSender(MessageSender):
                     tail_components,
                     failed_media_urls,
                 ) = await cls._build_media_components(effective_prepared)
+                cls._normalize_components_for_telegram(
+                    image_components,
+                    tail_components,
+                )
 
             message = cls._append_failed_media_links(message, failed_media_urls)
 


### PR DESCRIPTION
## Summary by Sourcery

在发送 Telegram 通知之前规范基于文件的媒体路径

Bug Fixes（错误修复）:
- 确保带有 `file://` URI 的 Telegram 媒体组件被转换为有效的本地路径，以防止在发送媒体消息时失败。

Enhancements（改进）:
- 在通过 Telegram 发送之前，将媒体组件中的 `file://` URI 转换为本地文件系统路径，包括对 Windows 特定路径的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize file-based media paths before sending Telegram notifications

Bug Fixes:
- Ensure Telegram media components with file:// URIs are converted to valid local paths to prevent failures when sending media messages.

Enhancements:
- Convert file:// URIs in media components to local filesystem paths, including Windows-specific handling, before sending via Telegram

</details>