### PR TITLE
chore(astrbot_plugin_rsshub): bump version to v1.0.4

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_rsshub
 display_name: RSS订阅插件
 desc: RSS 订阅插件，支持多平台消息推送。
-version: v1.0.3
+version: v1.0.4
 author: FlanChanXwO
 repo: https://github.com/FlanChanXwO/astrbot_plugin_rsshub

--- a/notifier/senders/aiocqhttp.py
+++ b/notifier/senders/aiocqhttp.py
@@ -133,33 +133,34 @@ class AiocqhttpMessageSender(MessageSender):
             return await cls._send_chain(session_id, [Nodes(nodes)])
         except Exception as err:
             logger.warning(
-                "Aiocqhttp merged-forward send failed, fallback to plain text: session=%s, err=%s",
+                "Aiocqhttp merged-forward send failed, trying text-only merged fallback: session=%s, err=%s",
                 session_id,
                 err,
             )
-            # Preserve media URLs when large media upload is rejected by upstream.
+
+            # Keep merged-forward mode even in fallback: convert media to links in text.
             fallback_urls: list[str] = []
             if media:
                 fallback_urls.extend([url for _, url in media if url])
             fallback_text = cls._append_failed_media_links(message, fallback_urls)
 
-            if not fallback_text:
-                return SendResult(
-                    ok=False,
-                    transient=cls._is_transient_network_error(err),
-                    detail=str(err),
-                )
+            if context:
+                nickname = context.channel.title if context.channel.title else "RSSHub"
+            else:
+                nickname = "RSSHub"
+
+            merged_text = fallback_text or "RSS update"
+            fallback_nodes = [cls._build_node(nickname, [Plain(merged_text)])]
 
             try:
                 fallback_result = await cls._send_chain(
-                    session_id,
-                    [Plain(fallback_text)],
+                    session_id, [Nodes(fallback_nodes)]
                 )
                 if fallback_result.ok:
                     return SendResult(
                         ok=True,
                         transient=False,
-                        detail="merged_forward_failed_text_fallback",
+                        detail="merged_forward_failed_text_nodes_fallback",
                     )
                 return fallback_result
             except Exception as fallback_ex:


### PR DESCRIPTION
## Summary by Sourcery

在合并转发消息发送失败时改进 RSSHub aiocqhttp 发送器的回退行为，并提升插件版本。

Bug 修复：
- 确保合并转发消息发送失败时，回退为仅含文本的「合并消息」而不是纯文本消息，从而保留合并转发的行为。

功能增强：
- 在为发送失败的合并转发构建回退用的合并节点时，使用频道标题或默认的 RSSHub 昵称，以及合理的默认消息内容。

构建：
- 将 astrbot_plugin_rsshub 插件版本从 v1.0.3 提升到 v1.0.4。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RSSHub aiocqhttp sender fallback behavior when merged-forward messages fail and bump the plugin version.

Bug Fixes:
- Ensure merged-forward message failures fall back to a text-only merged message instead of plain text, preserving merged-forward behavior.

Enhancements:
- Use the channel title or a default RSSHub nickname and a sensible default message when constructing fallback merged nodes for failed merged-forward sends.

Build:
- Bump astrbot_plugin_rsshub plugin version from v1.0.3 to v1.0.4.

</details>