### PR TITLE
fix transcation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@
 
 ### Fixed
 
-- 修复 SQLite 架构兼容检查中的 `PRAGMA table_info(?)` 语法问题：
-  - 改为使用经过标识符校验的 `PRAGMA table_info("table")` 调用
-  - 避免插件启动时出现 `near "?": syntax error` 导致载入失败
-  - 增加动态表名合法性校验，降低 SQL 注入风险
-
 - 修复 `selectinload` 类型注解警告，使用字符串形式避免 SQLAlchemy 2.0 类型检查问题
 
 ## [1.0.12] - 2026-04-13

--- a/db/models.py
+++ b/db/models.py
@@ -43,6 +43,12 @@ def _sqlite_table_info_sql(table: str) -> str:
     return f'PRAGMA table_info("{table}")'
 
 
+def _is_text_compatible_sqlite_type(column_type: str) -> bool:
+    """Return True when a SQLite declared type has TEXT affinity."""
+    normalized = (column_type or "").upper()
+    return any(token in normalized for token in ("TEXT", "CHAR", "CLOB"))
+
+
 async def _get_column_type(conn, table: str, column: str) -> str:
     """获取指定表的列类型"""
     rows = (await conn.exec_driver_sql(_sqlite_table_info_sql(table))).fetchall()
@@ -380,8 +386,8 @@ async def _migrate_user_id_to_text(conn) -> None:
         return
 
     user_id_type = await _get_column_type(conn, "rsshub_user", "id")
-    if user_id_type == "TEXT":
-        # 已经是 TEXT 类型，无需迁移
+    if _is_text_compatible_sqlite_type(user_id_type):
+        # TEXT affinity types in SQLite are already compatible (e.g. TEXT/VARCHAR).
         return
 
     if user_id_type != "INTEGER":

--- a/db/models.py
+++ b/db/models.py
@@ -33,21 +33,19 @@ EFFECTIVE_OPTION_KEYS = (
     "display_media",
 )
 
-
-# Restrict dynamic SQLite identifiers used in PRAGMA statements.
 _SQLITE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-async def _get_table_info_rows(conn, table: str) -> list:
-    """Return PRAGMA table_info rows for a validated table name."""
+def _sqlite_table_info_sql(table: str) -> str:
+    """Build PRAGMA table_info SQL with a validated table identifier."""
     if not _SQLITE_IDENTIFIER_RE.fullmatch(table):
-        raise ValueError(f"Invalid SQLite identifier: {table}")
-    return (await conn.exec_driver_sql(f'PRAGMA table_info("{table}")')).fetchall()
+        raise ValueError(f"Invalid sqlite table identifier: {table!r}")
+    return f'PRAGMA table_info("{table}")'
 
 
 async def _get_column_type(conn, table: str, column: str) -> str:
     """获取指定表的列类型"""
-    rows = await _get_table_info_rows(conn, table)
+    rows = (await conn.exec_driver_sql(_sqlite_table_info_sql(table))).fetchall()
     for row in rows:
         if row[1] == column:
             return row[2].upper()
@@ -312,7 +310,7 @@ async def _ensure_schema_compat(conn) -> None:
     """为旧数据库补齐迁移过程尚未纳入的新增列，并处理 user_id 类型迁移。"""
 
     async def _has_column(table: str, column: str) -> bool:
-        rows = await _get_table_info_rows(conn, table)
+        rows = (await conn.exec_driver_sql(_sqlite_table_info_sql(table))).fetchall()
         return any(row[1] == column for row in rows)
 
     # 新增列兼容（旧版本迁移）


### PR DESCRIPTION
## Summary by Sourcery

改进用于 `user_id` 迁移逻辑的 SQLite 模式兼容性处理和文本类型检测。

Bug Fixes:
- 当 `rsshub_user.id` 已经使用 SQLite 的 TEXT 亲和类型（TEXT-affinity type）而不是仅仅字面量 `TEXT` 时，防止发生错误的迁移。

Enhancements:
- 引入辅助工具，用于构建经过验证的 `PRAGMA table_info` SQL 语句以及检测 SQLite 的 TEXT 亲和声明类型，并在模式兼容性检查中复用这些工具。

Documentation:
- 更新变更日志，移除现已过时的、关于先前 SQLite PRAGMA 修复的说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve SQLite schema compatibility handling and text-type detection for user_id migration logic.

Bug Fixes:
- Prevent incorrect migration when rsshub_user.id already uses a SQLite TEXT-affinity type instead of only literal TEXT.

Enhancements:
- Introduce helpers to build validated PRAGMA table_info SQL and to detect SQLite TEXT-affinity declared types, and reuse them in schema compatibility checks.

Documentation:
- Update changelog by removing now-obsolete notes about a previous SQLite PRAGMA fix.

</details>