### PR TITLE
V1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [1.0.15] - 2026-04-17
+
+### Added
+
+- 新增微信个人号（`weixin_oc`）平台专用发送器策略，适配“每条消息只能包含一个消息组件”的平台约束：
+  - 图片、视频、音频、文件按单组件顺序发送
+  - 文本内容单独发送，避免将多组件消息链直接交给平台
+  - 媒体下载失败时，会在文本中附带原始链接作为兜底
+  - 新增配置项 `sender_strategy_weixin_oc`，可通过 `/rss_conf sender_strategy_weixin_oc <true/false>` 开启或关闭该策略
+
+### Changed
+
+- 去重与监控链路优化：
+  - 调整监控侧判重为“稳定身份优先 + 兼容指纹回退”，降低仅时间戳抖动导致的重复推送
+  - 新增/完善监控轮次结构化统计日志，包含抓取条数、去重新增/跳过、扇出订阅数及失败队列处理计数
+  - 首轮行为支持配置 `bootstrap_skip_history`（默认 `true`）：可选“仅建历史不推送”或“首轮补推历史”
+- 配置与命令入口同步：
+  - 新增配置项 `bootstrap_skip_history`，并接入配置加载/保存、`/rss_conf` 解析与展示
+  - `/rsshelp` 与配置项说明补充 `failed_queue_max_retries` 与 `bootstrap_skip_history`
+- 失败队列容量判定边界修正：
+  - `FailedNotification.is_at_capacity` 从 `>` 调整为 `>=`，达到容量即判满
+
+### Fixed
+
+- 修复 QQ Official 在 Docker 场景下图片媒体路径被错误解析导致的 `FileNotFoundError`：
+  - `file:///` 本地 URI 在发送前统一归一化为绝对本地路径，避免核心链路旧版切片逻辑（如 `i.file[8:]`）将路径误变为相对路径
+
+- 修复失败队列观测盲区：
+  - `Notifier` 增加失败入队、丢弃、处理成功、重试中、重试耗尽等统计计数，便于定位“漏推”来源
+
+### Docs
+
+- 文档同步更新：
+  - `README.md` 新增 `bootstrap_skip_history` 说明
+  - 明确“监控主循环无固定每周期条目上限”，实际受源更新量、失败队列容量、最大重试次数与平台限流影响
+
 ## [1.0.14] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 |--------------------|----|-------------------------------|------|
 | `default_interval` | 整数 | 默认监控间隔（分钟），订阅未设置 interval 时使用 | `10` |
 | `minimal_interval` | 整数 | 最小监控间隔（分钟），限制命令/WebUI 设置的最小值  | `1`  |
+| `bootstrap_skip_history` | 布尔值 | 首轮是否跳过历史条目，开启后首次仅建立去重历史不推送旧消息 | `true` |
 
 ### 去重配置
 
@@ -225,8 +226,10 @@
 | `/rsshelp` | `/RSS帮助` | 查看帮助 |
 
 **可配置项：** `proxy`/`rsshub_base_url`/`default_interval`/`minimal_interval`/`timeout`/`download_image_before_send`/
-`failed_queue_capacity`/`sender_strategy_telegram`/`sender_strategy_aiocqhttp`/`deduplicate_multi_bot`/
-`platform_shared_data_aiocqhttp`
+`bootstrap_skip_history`/`failed_queue_capacity`/`failed_queue_max_retries`/`sender_strategy_telegram`/`sender_strategy_aiocqhttp`/
+`deduplicate_multi_bot`/`platform_shared_data_aiocqhttp`
+
+> 说明：监控主循环没有固定“每周期条目上限”。实际可见推送量受 RSS 源更新量、失败队列容量（`failed_queue_capacity`）、最大重试次数（`failed_queue_max_retries`）以及平台发送限流共同影响。
 
 ### 订阅选项说明
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -69,7 +69,7 @@
   },
   "download_image_before_send": {
     "type": "bool",
-    "description": "先下载图片再发送",
+    "description": "先下载媒体后发送",
     "hint": "开启后会先下载媒体到本地再推送，可复用缓存，但是在docker环境下需要共享数据卷",
     "default": false
   },
@@ -91,7 +91,8 @@
     "hint": "配置各平台使用的发送策略。关闭特定平台策略后将使用默认发送策略",
     "default": {
       "telegram": true,
-      "aiocqhttp": true
+      "aiocqhttp": true,
+      "weixin_oc": true
     },
     "items": {
       "telegram": {
@@ -105,6 +106,12 @@
         "description": "启用 OneBot 专用发送策略",
         "hint": "启用后将使用 OneBot 优化策略（合并转发节点）。关闭则使用默认策略",
         "default": true
+      },
+      "weixin_oc": {
+        "type": "bool",
+        "description": "启用微信个人号专用发送策略",
+        "hint": "启用后将使用微信个人号优化策略（单组件顺序发送）。关闭则使用默认策略",
+        "default": true
       }
     }
   },
@@ -112,6 +119,12 @@
     "type": "bool",
     "description": "单会话多 BOT 去重",
     "hint": "开启后，当同一会话中有多个 BOT 订阅了相同的 RSS 源，只有最早订阅的 BOT 会推送消息，避免重复推送",
+    "default": true
+  },
+  "bootstrap_skip_history": {
+    "type": "bool",
+    "description": "首轮跳过历史条目",
+    "hint": "开启后，首次监控仅建立去重历史不推送旧条目；关闭后首次监控会按抓取结果推送历史条目",
     "default": true
   },
   "platform_shared_data": {

--- a/db/models.py
+++ b/db/models.py
@@ -1140,7 +1140,7 @@ class FailedNotificationMethods:
             )
             result = await session.execute(stmt)
             rows = result.all()
-            return len(rows) > capacity
+            return len(rows) >= capacity
 
     @staticmethod
     async def count_by_sub_ids(sub_ids: list[int]) -> dict[int, int]:

--- a/main.py
+++ b/main.py
@@ -88,7 +88,9 @@ PLUGIN_CONFIG_KEYS = {
     "failed_queue_max_retries",
     "sender_strategy_telegram",
     "sender_strategy_aiocqhttp",
+    "sender_strategy_weixin_oc",
     "deduplicate_multi_bot",
+    "bootstrap_skip_history",
     "platform_shared_data_aiocqhttp",
 }
 
@@ -191,6 +193,14 @@ class RSSHubPlugin(Star):
                 return False
             raise ValueError("download_image_before_send 仅支持布尔值: true/false")
 
+        if normalized_key == "bootstrap_skip_history":
+            lowered = raw_value.lower()
+            if lowered in {"1", "true", "yes", "on", "enable", "enabled"}:
+                return True
+            if lowered in {"0", "false", "no", "off", "disable", "disabled"}:
+                return False
+            raise ValueError("bootstrap_skip_history 仅支持布尔值: true/false")
+
         if normalized_key == "proxy":
             return raw_value
 
@@ -208,6 +218,7 @@ class RSSHubPlugin(Star):
         if normalized_key in {
             "sender_strategy_telegram",
             "sender_strategy_aiocqhttp",
+            "sender_strategy_weixin_oc",
             "deduplicate_multi_bot",
             "platform_shared_data_aiocqhttp",
         }:
@@ -1865,11 +1876,13 @@ class RSSHubPlugin(Star):
                 f"failed_queue_capacity = {self.config.failed_queue_capacity}\n"
                 f"failed_queue_max_retries = {self.config.failed_queue_max_retries}\n"
                 f"deduplicate_multi_bot = {self.config.deduplicate_multi_bot}\n"
+                f"bootstrap_skip_history = {self.config.bootstrap_skip_history}\n"
                 "download_image_before_send = "
                 f"{self.config.download_image_before_send}\n"
                 "sender_strategies:\n"
                 f"  telegram = {strategies.get('telegram', True)}\n"
                 f"  aiocqhttp = {strategies.get('aiocqhttp', True)}\n"
+                f"  weixin_oc = {strategies.get('weixin_oc', True)}\n"
                 "platform_shared_data:\n"
                 f"  aiocqhttp = {shared_data.get('aiocqhttp', False)}"
             )
@@ -1879,8 +1892,10 @@ class RSSHubPlugin(Star):
             yield event.plain_result(
                 "不支持的配置项。可用项: "
                 "proxy/rsshub_base_url/default_interval/minimal_interval/timeout/"
-                "download_image_before_send/failed_queue_capacity/failed_queue_max_retries/"
+                "download_image_before_send/bootstrap_skip_history/"
+                "failed_queue_capacity/failed_queue_max_retries/"
                 "sender_strategy_telegram/sender_strategy_aiocqhttp/"
+                "sender_strategy_weixin_oc/"
                 "deduplicate_multi_bot/platform_shared_data_aiocqhttp"
             )
             return
@@ -1982,8 +1997,9 @@ class RSSHubPlugin(Star):
             + "- target_session: private/group/current 或完整 session\n\n"
             + "插件配置项:\n"
             + "- proxy/rsshub_base_url/default_interval/minimal_interval/timeout/"
-            + "download_image_before_send/failed_queue_capacity\n"
-            + "- sender_strategy_telegram/sender_strategy_aiocqhttp: 平台发送策略开关\n"
+            + "download_image_before_send/bootstrap_skip_history/"
+            + "failed_queue_capacity/failed_queue_max_retries\n"
+            + "- sender_strategy_telegram/sender_strategy_aiocqhttp/sender_strategy_weixin_oc: 平台发送策略开关\n"
             + "- deduplicate_multi_bot: 单会话多BOT去重（默认true）\n"
             + "- platform_shared_data_aiocqhttp: aiocqhttp平台共享数据源（默认false）\n\n"
             + "会话级默认配置项:\n"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_rsshub
 display_name: RSS订阅
 desc: 多平台RSS订阅推送插件，支持失败队列重试、多BOT去重、平台数据共享、智能发送策略，LLM工具调用，让你的BOT成为信息聚合中心。
-version: v1.0.14
+version: v1.0.15
 author: FlanChanXwO
 repo: https://github.com/FlanChanXwO/astrbot_plugin_rsshub

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -341,13 +341,16 @@ class RSSMonitor:
                     feed_updated_fields.add("title")
 
                 old_hashes = list(feed.entry_hashes or [])
+                fetched_entries = len(rss_d.entries)
                 new_hashes, updated_entries = self._calculate_update(
                     old_hashes, rss_d.entries
                 )
+                dedup_new_count = len(updated_entries)
+                dedup_skipped_count = max(0, fetched_entries - dedup_new_count)
                 merged_hashes = self._merge_hash_history(
                     old_hashes,
                     new_hashes,
-                    len(rss_d.entries),
+                    fetched_entries,
                 )
 
                 if not old_hashes:
@@ -356,7 +359,63 @@ class RSSMonitor:
                     feed_updated_fields.update({"last_modified", "entry_hashes"})
                     schedule_action = ("success", None)
                     self._stat.not_updated()
-                    logger.info(f"Feed首次初始化完成（不推送历史内容）: {feed.link}")
+                    if self._config_value("bootstrap_skip_history", True):
+                        logger.info(
+                            "Feed首次初始化完成（不推送历史内容）: %s, fetched_entries=%s, bootstrap_skipped_count=%s",
+                            feed.link,
+                            fetched_entries,
+                            fetched_entries,
+                        )
+                    else:
+                        logger.info(
+                            "Feed首次初始化推送历史内容: %s, fetched_entries=%s, bootstrap_sent_count=%s",
+                            feed.link,
+                            fetched_entries,
+                            dedup_new_count,
+                        )
+                        ordered_entries = list(reversed(updated_entries))
+                        fanout_subs = subs
+                        if feed.id is not None:
+                            fanout_subs = await Sub.get_active_by_feed_id(feed.id)
+
+                        dedup_before_sub_count = len(fanout_subs)
+                        if self.config and getattr(
+                            self.config, "deduplicate_multi_bot", True
+                        ):
+                            fanout_subs = self._deduplicate_session_subscriptions(
+                                fanout_subs
+                            )
+                        fanout_sub_count = len(fanout_subs)
+
+                        notifier = Notifier(
+                            feed=feed,
+                            subs=fanout_subs,
+                            entries=ordered_entries,
+                            timeout_seconds=self.config.timeout if self.config else 30,
+                            proxy=self.config.proxy if self.config else "",
+                            download_media_before_send=(
+                                self.config.download_image_before_send
+                                if self.config
+                                else True
+                            ),
+                            config=self.config,
+                        )
+                        await notifier.notify_all()
+                        logger.info(
+                            "Feed轮询统计: feed=%s, fetched_entries=%s, dedup_new_count=%s, dedup_skipped_count=%s, fanout_sub_count=%s, dedup_before_sub_count=%s, enqueue_failed_count=%s, failed_drop_count=%s, failed_process_count=%s, failed_process_success_count=%s, failed_process_retry_count=%s, failed_process_exhausted_count=%s",
+                            feed.link,
+                            fetched_entries,
+                            dedup_new_count,
+                            dedup_skipped_count,
+                            fanout_sub_count,
+                            dedup_before_sub_count,
+                            notifier.stats["enqueue_failed_count"],
+                            notifier.stats["failed_drop_count"],
+                            notifier.stats["failed_process_count"],
+                            notifier.stats["failed_process_success_count"],
+                            notifier.stats["failed_process_retry_count"],
+                            notifier.stats["failed_process_exhausted_count"],
+                        )
 
                 elif not updated_entries:
                     if merged_hashes != old_hashes:
@@ -380,6 +439,7 @@ class RSSMonitor:
                         # avoiding chunk-based preemption between sessions/platforms.
                         fanout_subs = await Sub.get_active_by_feed_id(feed.id)
 
+                    dedup_before_sub_count = len(fanout_subs)
                     # Apply multi-bot deduplication if enabled
                     if self.config and getattr(
                         self.config, "deduplicate_multi_bot", True
@@ -387,8 +447,9 @@ class RSSMonitor:
                         fanout_subs = self._deduplicate_session_subscriptions(
                             fanout_subs
                         )
+                    fanout_sub_count = len(fanout_subs)
 
-                    await Notifier(
+                    notifier = Notifier(
                         feed=feed,
                         subs=fanout_subs,
                         entries=ordered_entries,
@@ -400,7 +461,23 @@ class RSSMonitor:
                             else True
                         ),
                         config=self.config,
-                    ).notify_all()
+                    )
+                    await notifier.notify_all()
+                    logger.info(
+                        "Feed轮询统计: feed=%s, fetched_entries=%s, dedup_new_count=%s, dedup_skipped_count=%s, fanout_sub_count=%s, dedup_before_sub_count=%s, enqueue_failed_count=%s, failed_drop_count=%s, failed_process_count=%s, failed_process_success_count=%s, failed_process_retry_count=%s, failed_process_exhausted_count=%s",
+                        feed.link,
+                        fetched_entries,
+                        dedup_new_count,
+                        dedup_skipped_count,
+                        fanout_sub_count,
+                        dedup_before_sub_count,
+                        notifier.stats["enqueue_failed_count"],
+                        notifier.stats["failed_drop_count"],
+                        notifier.stats["failed_process_count"],
+                        notifier.stats["failed_process_success_count"],
+                        notifier.stats["failed_process_retry_count"],
+                        notifier.stats["failed_process_exhausted_count"],
+                    )
                     schedule_action = ("success", None)
                     self._stat.updated()
         finally:
@@ -540,22 +617,39 @@ class RSSMonitor:
     ) -> tuple[list[str], list]:
         """计算哪些条目是新的。"""
         old_hashes_set = {h for h in old_hashes if h}
+        known_hashes = set(old_hashes_set)
         new_hashes = []
         new_hashes_seen: set[str] = set()
         updated_entries = []
 
         for entry in entries:
             entry_hashes = self._hash_entry(entry)
+            stable_hash = next(
+                (h for h in entry_hashes if self._is_identity_hash(h)),
+                entry_hashes[0] if entry_hashes else "",
+            )
 
-            if not any(entry_hash in old_hashes_set for entry_hash in entry_hashes):
+            stable_aliases = {stable_hash} if stable_hash else set()
+            if stable_hash.startswith("sid:"):
+                stable_aliases.add(stable_hash[4:])
+
+            known_by_stable = any(alias in known_hashes for alias in stable_aliases)
+            known_by_compat = (
+                not known_by_stable
+                and any(entry_hash in known_hashes for entry_hash in entry_hashes)
+            )
+
+            if not known_by_stable and not known_by_compat:
                 updated_entries.append(entry)
 
             for entry_hash in entry_hashes:
                 if entry_hash not in new_hashes_seen:
                     new_hashes_seen.add(entry_hash)
                     new_hashes.append(entry_hash)
+                known_hashes.add(entry_hash)
 
         return new_hashes, updated_entries
+
 
     @staticmethod
     def _normalize_text(value: str, max_length: int = 1024) -> str:
@@ -669,6 +763,10 @@ class RSSMonitor:
         return ""
 
     @staticmethod
+    def _is_identity_hash(value: str) -> bool:
+        return value.startswith("sid:")
+
+    @staticmethod
     def _sha256(value: str) -> str:
         return hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest()
 
@@ -682,8 +780,39 @@ class RSSMonitor:
         )
         return str(zlib.crc32(hash_base.encode()))
 
+    @staticmethod
+    def _upstream_compatible_material(entry) -> str:
+        """Build upstream-compatible identity material.
+
+        Order: guid -> link -> title -> summary -> first content.value.
+        """
+        guid = str(entry.get("guid") or "").strip()
+        link = str(entry.get("link") or "").strip()
+        title = str(entry.get("title") or "").strip()
+        summary = str(entry.get("summary") or "").strip()
+
+        content_items = entry.get("content") or []
+        first_content_value = ""
+        if isinstance(content_items, list):
+            for content in content_items:
+                if isinstance(content, dict):
+                    value = content.get("value")
+                    if value:
+                        first_content_value = str(value).strip()
+                        break
+
+        return "\n".join([guid, link, title, summary, first_content_value])
+
+
     def _hash_entry(self, entry) -> list[str]:
         """Calculate a robust dedupe fingerprint set for one entry."""
+        upstream_material = self._upstream_compatible_material(entry)
+        upstream_crc = (
+            hex(zlib.crc32(upstream_material.encode("utf-8", errors="ignore")))[2:]
+            if upstream_material
+            else ""
+        )
+
         entry_id = self._normalize_identifier(
             str(entry.get("id") or entry.get("guid") or "")
         )
@@ -695,27 +824,35 @@ class RSSMonitor:
         )
         published_ts = self._format_entry_timestamp(entry)
 
-        if entry_id:
-            stable_key = f"id={entry_id}"
-        elif link:
+        if link:
             stable_key = f"link={link}"
+        elif entry_id:
+            stable_key = f"id={entry_id}"
         elif title:
             stable_key = f"title={title}"
         else:
             stable_key = f"summary={summary[:256]}"
 
-        # Primary fingerprint prefers stable identity fields and normalized timestamp.
-        primary_material = f"v2|{stable_key}|ts={published_ts}"
+        stable_material = f"v3|{stable_key}"
+        content_material = f"v3|title={title}|link={link}|summary={summary[:512]}"
+        timestamp_material = f"v3|{stable_key}|ts={published_ts}" if published_ts else ""
 
-        # Secondary fingerprint keeps content context to reduce false positives.
-        secondary_material = (
-            f"v2|title={title}|link={link}|summary={summary[:512]}|ts={published_ts}"
-        )
+        fingerprints: list[str] = []
 
-        fingerprints = [self._sha256(primary_material)]
-        secondary_hash = self._sha256(secondary_material)
-        if secondary_hash != fingerprints[0]:
-            fingerprints.append(secondary_hash)
+        stable_hash = f"sid:{self._sha256(stable_material)}"
+        fingerprints.append(stable_hash)
+
+        content_hash = self._sha256(content_material)
+        if content_hash not in fingerprints:
+            fingerprints.append(content_hash)
+
+        if upstream_crc and upstream_crc not in fingerprints:
+            fingerprints.append(upstream_crc)
+
+        if timestamp_material:
+            timestamp_hash = self._sha256(timestamp_material)
+            if timestamp_hash not in fingerprints:
+                fingerprints.append(timestamp_hash)
 
         # Keep legacy v1 crc32 fingerprint to avoid full re-push after upgrading.
         legacy_hash = self._legacy_entry_crc32(entry)

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -634,9 +634,8 @@ class RSSMonitor:
                 stable_aliases.add(stable_hash[4:])
 
             known_by_stable = any(alias in known_hashes for alias in stable_aliases)
-            known_by_compat = (
-                not known_by_stable
-                and any(entry_hash in known_hashes for entry_hash in entry_hashes)
+            known_by_compat = not known_by_stable and any(
+                entry_hash in known_hashes for entry_hash in entry_hashes
             )
 
             if not known_by_stable and not known_by_compat:
@@ -649,7 +648,6 @@ class RSSMonitor:
                 known_hashes.add(entry_hash)
 
         return new_hashes, updated_entries
-
 
     @staticmethod
     def _normalize_text(value: str, max_length: int = 1024) -> str:
@@ -803,7 +801,6 @@ class RSSMonitor:
 
         return "\n".join([guid, link, title, summary, first_content_value])
 
-
     def _hash_entry(self, entry) -> list[str]:
         """Calculate a robust dedupe fingerprint set for one entry."""
         upstream_material = self._upstream_compatible_material(entry)
@@ -835,7 +832,9 @@ class RSSMonitor:
 
         stable_material = f"v3|{stable_key}"
         content_material = f"v3|title={title}|link={link}|summary={summary[:512]}"
-        timestamp_material = f"v3|{stable_key}|ts={published_ts}" if published_ts else ""
+        timestamp_material = (
+            f"v3|{stable_key}|ts={published_ts}" if published_ts else ""
+        )
 
         fingerprints: list[str] = []
 

--- a/notifier/notifier.py
+++ b/notifier/notifier.py
@@ -40,6 +40,18 @@ class Notifier:
         self.proxy = proxy or ""
         self.download_media_before_send = bool(download_media_before_send)
         self.config = config
+        self._stats = {
+            "enqueue_failed_count": 0,
+            "failed_drop_count": 0,
+            "failed_process_count": 0,
+            "failed_process_success_count": 0,
+            "failed_process_retry_count": 0,
+            "failed_process_exhausted_count": 0,
+        }
+
+    @property
+    def stats(self) -> dict[str, int]:
+        return dict(self._stats)
 
     def _build_context(self, sub: Sub) -> NotifierContext:
         """构建通知上下文"""
@@ -306,6 +318,7 @@ class Notifier:
                     "Failed notification queue disabled (capacity=%s), dropping message",
                     max_capacity,
                 )
+                self._stats["failed_drop_count"] += 1
                 return
 
             # Use cheaper capacity check to reduce DB load
@@ -315,6 +328,7 @@ class Notifier:
                     "Failed notification queue full for sub=%s, dropping message",
                     sub.id,
                 )
+                self._stats["failed_drop_count"] += 1
                 return
 
             # Build media URLs list
@@ -341,12 +355,14 @@ class Notifier:
                 options=options,
                 fail_reason=fail_reason,
             )
+            self._stats["enqueue_failed_count"] += 1
             logger.info(
                 "Enqueued failed notification for retry: sub=%s, reason=%s",
                 sub.id,
                 fail_reason,
             )
         except Exception as ex:
+            self._stats["failed_drop_count"] += 1
             logger.error("Failed to enqueue notification: %s", ex)
 
     async def _process_failed_queue(
@@ -373,13 +389,23 @@ class Notifier:
             )
 
             for notif in pending:
-                await process_failed_notification(
+                self._stats["failed_process_count"] += 1
+                success, _detail = await process_failed_notification(
                     notif,
                     config=self.config,
                     timeout_seconds=self.timeout_seconds,
                     proxy=self.proxy,
                     max_retries=max_retries,
                 )
+                if success:
+                    self._stats["failed_process_success_count"] += 1
+                    continue
+
+                next_retry = notif.retry_count + 1
+                if next_retry >= max_retries:
+                    self._stats["failed_process_exhausted_count"] += 1
+                else:
+                    self._stats["failed_process_retry_count"] += 1
 
         except Exception as ex:
             logger.error("Failed to process failed queue for sub=%s: %s", sub.id, ex)

--- a/notifier/senders/__init__.py
+++ b/notifier/senders/__init__.py
@@ -3,11 +3,13 @@ from .base import MessageSender
 from .factory import get_sender_for_platform_name
 from .telegram import TelegramMessageSender
 from .types import ChannelInfo, NotifierContext, SendResult, set_bot_self_id_provider
+from .weixin_oc import WeixinOCMessageSender
 
 __all__ = [
     "MessageSender",
     "AiocqhttpMessageSender",
     "TelegramMessageSender",
+    "WeixinOCMessageSender",
     "SendResult",
     "ChannelInfo",
     "NotifierContext",

--- a/notifier/senders/base.py
+++ b/notifier/senders/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from astrbot.api import logger
 from astrbot.api.message_components import File, Image, Plain, Record, Video

--- a/notifier/senders/base.py
+++ b/notifier/senders/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from urllib.parse import unquote, urlparse
 
 from astrbot.api import logger
 from astrbot.api.message_components import File, Image, Plain, Record, Video
@@ -9,6 +8,7 @@ from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.star.star_tools import StarTools
 
 from .media_downloader import get_or_download_media_to_cache
+from .media_paths import normalize_local_media_file_value
 from .types import PreparedMedia, SendResult
 
 
@@ -250,20 +250,6 @@ class MessageSender:
         return "\n".join(lines)
 
     @staticmethod
-    def _resolve_local_file_path(file_value: str) -> str | None:
-        if not file_value or not isinstance(file_value, str):
-            return None
-        if not file_value.startswith("file:///"):
-            return None
-        parsed = urlparse(file_value)
-        if parsed.scheme != "file":
-            return None
-        local_path = unquote(parsed.path or "")
-        if local_path.startswith("/") and len(local_path) >= 3 and local_path[2] == ":":
-            local_path = local_path[1:]
-        return local_path or None
-
-    @staticmethod
     def _collect_normalizable_components(items: list) -> list[object]:
         collected: list[object] = []
 
@@ -281,7 +267,9 @@ class MessageSender:
             content = getattr(value, "content", None)
             if isinstance(content, list):
                 _walk(content)
-            collected.append(value)
+            file_value = getattr(value, "file", None)
+            if isinstance(file_value, str):
+                collected.append(value)
 
         _walk(items)
         return collected
@@ -294,9 +282,8 @@ class MessageSender:
                 continue
             if file_value.startswith(("http://", "https://", "base64://")):
                 continue
-            local_path = cls._resolve_local_file_path(file_value) or file_value
             try:
-                resolved = str(Path(local_path).resolve())
+                resolved = normalize_local_media_file_value(file_value)
                 exists = Path(resolved).exists()
             except Exception as ex:
                 logger.warning(

--- a/notifier/senders/base.py
+++ b/notifier/senders/base.py
@@ -105,9 +105,10 @@ class MessageSender:
                 )
                 failure_by_url[media_url] = True
                 logger.warning(
-                    "Prepare media failed: type=%s, url=%s, err=%s",
+                    "Prepare media failed: type=%s, url=%s, err_type=%s, err=%r",
                     media_type,
                     media_url,
+                    type(ex).__name__,
                     ex,
                 )
 
@@ -197,6 +198,14 @@ class MessageSender:
 
             local_file_path = str(local_path.resolve()) if local_path else ""
             local_file_uri = local_path.resolve().as_uri() if local_path else ""
+            if local_path is not None:
+                logger.debug(
+                    "Prepared local media path: type=%s, url=%s, resolved=%s, exists=%s",
+                    media_type,
+                    media_url,
+                    local_file_path,
+                    local_path.exists(),
+                )
             media_file_value = local_file_uri if local_path else media_url
 
             if media_type == "image":
@@ -241,6 +250,76 @@ class MessageSender:
         return "\n".join(lines)
 
     @staticmethod
+    def _resolve_local_file_path(file_value: str) -> str | None:
+        if not file_value or not isinstance(file_value, str):
+            return None
+        if not file_value.startswith("file:///"):
+            return None
+        parsed = urlparse(file_value)
+        if parsed.scheme != "file":
+            return None
+        local_path = unquote(parsed.path or "")
+        if local_path.startswith("/") and len(local_path) >= 3 and local_path[2] == ":":
+            local_path = local_path[1:]
+        return local_path or None
+
+    @staticmethod
+    def _collect_normalizable_components(items: list) -> list[object]:
+        collected: list[object] = []
+
+        def _walk(value: object) -> None:
+            if value is None:
+                return
+            if isinstance(value, (list, tuple)):
+                for nested in value:
+                    _walk(nested)
+                return
+            nodes = getattr(value, "nodes", None)
+            if isinstance(nodes, list):
+                _walk(nodes)
+                return
+            content = getattr(value, "content", None)
+            if isinstance(content, list):
+                _walk(content)
+            collected.append(value)
+
+        _walk(items)
+        return collected
+
+    @classmethod
+    def _normalize_chain_media_files(cls, chain: list, session_id: str) -> list:
+        for component in cls._collect_normalizable_components(chain):
+            file_value = getattr(component, "file", None)
+            if not isinstance(file_value, str) or not file_value:
+                continue
+            if file_value.startswith(("http://", "https://", "base64://")):
+                continue
+            local_path = cls._resolve_local_file_path(file_value) or file_value
+            try:
+                resolved = str(Path(local_path).resolve())
+                exists = Path(resolved).exists()
+            except Exception as ex:
+                logger.warning(
+                    "Sender media normalize failed: session=%s, component=%s, file=%s, err=%s",
+                    session_id,
+                    type(component).__name__,
+                    file_value,
+                    ex,
+                )
+                continue
+            if resolved != file_value:
+                setattr(component, "file", resolved)
+            logger.debug(
+                "Sender media normalized: session=%s, component=%s, original=%s, normalized=%s, exists=%s",
+                session_id,
+                type(component).__name__,
+                file_value,
+                resolved,
+                exists,
+            )
+        return chain
+
+    @staticmethod
     def _format_media_urls(media: list[tuple[str, str]] | None) -> str:
         if not media:
             return "[]"
@@ -261,9 +340,12 @@ class MessageSender:
         )
         return any(keyword in text for keyword in keywords)
 
-    @staticmethod
-    async def _send_chain(session_id: str, chain: list) -> SendResult:
-        message_chain = MessageChain(chain)
+    @classmethod
+    async def _send_chain(cls, session_id: str, chain: list) -> SendResult:
+        normalized_chain = cls._normalize_chain_media_files(chain, session_id)
+        if normalized_chain is None:
+            normalized_chain = []
+        message_chain = MessageChain(chain=normalized_chain)
         sent = await StarTools.send_message(session_id, message_chain)
         if not sent:
             return SendResult(ok=False, needs_rebind=True, detail="platform_or_session")

--- a/notifier/senders/factory.py
+++ b/notifier/senders/factory.py
@@ -4,6 +4,7 @@ from .aiocqhttp import AiocqhttpMessageSender
 from .base import MessageSender
 from .qq_official import QQOfficialMessageSender
 from .telegram import TelegramMessageSender
+from .weixin_oc import WeixinOCMessageSender
 
 
 def get_sender_for_platform_name(
@@ -24,7 +25,12 @@ def get_sender_for_platform_name(
     # Check if config has sender_strategies
     strategies = getattr(config, "sender_strategies", None) if config else None
     if strategies is None:
-        strategies = {"telegram": True, "aiocqhttp": True, "qq_official": True}
+        strategies = {
+            "telegram": True,
+            "aiocqhttp": True,
+            "qq_official": True,
+            "weixin_oc": True,
+        }
 
     # Telegram strategy
     if normalized in {"telegram", "tg"} or "telegram" in normalized:
@@ -50,6 +56,26 @@ def get_sender_for_platform_name(
     if "qq_official" in normalized or "qqofficial" in normalized:
         if strategies.get("qq_official", True):
             return QQOfficialMessageSender
+        return MessageSender
+
+    # Weixin personal strategy
+    if normalized in {
+        "weixin_oc",
+        "weixin_personal",
+        "wechat",
+        "wechat_personal",
+        "weixin",
+    }:
+        if strategies.get("weixin_oc", True):
+            return WeixinOCMessageSender
+        return MessageSender
+    if (
+        "weixin_oc" in normalized
+        or "weixin_personal" in normalized
+        or "wechat_personal" in normalized
+    ):
+        if strategies.get("weixin_oc", True):
+            return WeixinOCMessageSender
         return MessageSender
 
     return MessageSender

--- a/notifier/senders/media_downloader.py
+++ b/notifier/senders/media_downloader.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import aiohttp
 
@@ -59,6 +60,20 @@ def _guess_suffix(url: str) -> str:
     return ".bin"
 
 
+def _expand_download_candidates(url: str) -> list[str]:
+    candidates = [url]
+    try:
+        parsed = urlparse(url)
+        wrapped_values = parse_qs(parsed.query).get("url", [])
+        for wrapped in wrapped_values:
+            if wrapped.startswith("http://") or wrapped.startswith("https://"):
+                if wrapped not in candidates:
+                    candidates.append(wrapped)
+    except Exception:
+        pass
+    return candidates
+
+
 async def download_media_to_temp(
     *,
     url: str,
@@ -67,38 +82,78 @@ async def download_media_to_temp(
 ) -> Path:
     timeout = aiohttp.ClientTimeout(total=max(1, int(timeout_seconds)))
 
-    async with aiohttp.ClientSession(
-        timeout=timeout,
-        trust_env=True,
-        connector=build_tls_connector(),
-    ) as session:
-        async with session.get(
+    last_err: Exception | None = None
+    for candidate_url in _expand_download_candidates(url):
+        logger.debug(
+            "Media download attempt: origin=%s, candidate=%s, timeout_seconds=%s, proxy_enabled=%s",
             url,
-            proxy=proxy or None,
-            allow_redirects=True,
-            max_redirects=10,
-        ) as resp:
-            if resp.history:
-                logger.debug(
-                    "Media redirect followed: origin=%s, final=%s, hops=%s",
-                    url,
-                    str(resp.url),
-                    len(resp.history),
-                )
-            if resp.status >= 400:
-                raise RuntimeError(f"download failed: status={resp.status}, url={url}")
-            data = await resp.read()
-            if not data:
-                raise RuntimeError(f"download failed: empty response, url={url}")
+            candidate_url,
+            timeout_seconds,
+            bool(proxy),
+        )
+        try:
+            async with aiohttp.ClientSession(
+                timeout=timeout,
+                trust_env=True,
+                connector=build_tls_connector(),
+            ) as session:
+                async with session.get(
+                    candidate_url,
+                    proxy=proxy or None,
+                    allow_redirects=True,
+                    max_redirects=10,
+                ) as resp:
+                    if resp.history:
+                        logger.debug(
+                            "Media redirect followed: origin=%s, candidate=%s, final=%s, hops=%s",
+                            url,
+                            candidate_url,
+                            str(resp.url),
+                            len(resp.history),
+                        )
+                    if resp.status >= 400:
+                        raise RuntimeError(
+                            f"download failed: status={resp.status}, url={candidate_url}"
+                        )
+                    data = await resp.read()
+                    if not data:
+                        raise RuntimeError(
+                            f"download failed: empty response, url={candidate_url}"
+                        )
 
-    fd, tmp_name = tempfile.mkstemp(prefix="rsshub_media_", suffix=_guess_suffix(url))
-    try:
-        with os.fdopen(fd, "wb") as fp:
-            fp.write(data)
-    except Exception:
-        Path(tmp_name).unlink(missing_ok=True)
-        raise
-    return Path(tmp_name)
+            fd, tmp_name = tempfile.mkstemp(
+                prefix="rsshub_media_",
+                suffix=_guess_suffix(candidate_url),
+            )
+            try:
+                with os.fdopen(fd, "wb") as fp:
+                    fp.write(data)
+            except Exception:
+                Path(tmp_name).unlink(missing_ok=True)
+                raise
+            logger.debug(
+                "Media download success: origin=%s, candidate=%s, bytes=%s, tmp=%s",
+                url,
+                candidate_url,
+                len(data),
+                tmp_name,
+            )
+            return Path(tmp_name)
+        except Exception as ex:
+            last_err = ex
+            logger.warning(
+                "Media download attempt failed: origin=%s, candidate=%s, err_type=%s, err=%r",
+                url,
+                candidate_url,
+                type(ex).__name__,
+                ex,
+            )
+
+    if last_err is not None:
+        raise RuntimeError(
+            f"download failed for all candidates, url={url}, last_error={last_err!r}"
+        ) from last_err
+    raise RuntimeError(f"download failed for all candidates, url={url}")
 
 
 def safe_unlink(path: Path | None) -> None:
@@ -242,15 +297,38 @@ def _read_cache(url: str) -> Path | None:
     file_path = _cache_file_path(url)
     meta_path = _cache_meta_path(url)
     if not file_path.exists() or not meta_path.exists():
+        logger.debug(
+            "Media cache miss: url=%s, file_exists=%s, meta_exists=%s, file=%s, meta=%s",
+            url,
+            file_path.exists(),
+            meta_path.exists(),
+            file_path,
+            meta_path,
+        )
         return None
 
     try:
         expire_ts = float(meta_path.read_text(encoding="utf-8").strip())
     except Exception:
+        logger.debug(
+            "Media cache meta invalid: url=%s, meta=%s",
+            url,
+            meta_path,
+        )
         return None
 
-    if expire_ts < time.time():
+    now_ts = time.time()
+    if expire_ts < now_ts:
+        logger.debug(
+            "Media cache expired: url=%s, now=%s, expire=%s, file=%s",
+            url,
+            now_ts,
+            expire_ts,
+            file_path,
+        )
         return None
+
+    logger.debug("Media cache hit: url=%s, file=%s", url, file_path)
     return file_path
 
 
@@ -261,6 +339,15 @@ def _write_cache(url: str, source: Path) -> Path:
     cache_path.write_bytes(source.read_bytes())
     expire_ts = time.time() + _CACHE_TTL_SECONDS
     meta_path.write_text(str(expire_ts), encoding="utf-8")
+    logger.debug(
+        "Media cache write: url=%s, cache=%s, meta=%s, cache_exists=%s, meta_exists=%s, expire=%s",
+        url,
+        cache_path,
+        meta_path,
+        cache_path.exists(),
+        meta_path.exists(),
+        expire_ts,
+    )
     return cache_path
 
 
@@ -275,19 +362,39 @@ async def get_or_download_media_to_cache(
     async with _cache_io_lock:
         cached = _read_cache(url)
         if cached is not None:
+            logger.debug("Media cache return existing: url=%s, path=%s", url, cached)
             return cached
 
+    logger.debug(
+        "Media cache download start: url=%s, timeout_seconds=%s, proxy_enabled=%s",
+        url,
+        timeout_seconds,
+        bool(proxy),
+    )
     tmp_path = await download_media_to_temp(
         url=url,
         timeout_seconds=timeout_seconds,
         proxy=proxy,
+    )
+    logger.debug(
+        "Media cache download complete: url=%s, tmp=%s, tmp_exists=%s",
+        url,
+        tmp_path,
+        tmp_path.exists(),
     )
     try:
         async with _cache_io_lock:
             # Another task may have filled cache while we were downloading.
             cached = _read_cache(url)
             if cached is not None:
+                logger.debug(
+                    "Media cache filled by peer task: url=%s, path=%s",
+                    url,
+                    cached,
+                )
                 return cached
-            return _write_cache(url, tmp_path)
+            written = _write_cache(url, tmp_path)
+            logger.debug("Media cache return new write: url=%s, path=%s", url, written)
+            return written
     finally:
         safe_unlink(tmp_path)

--- a/notifier/senders/media_downloader.py
+++ b/notifier/senders/media_downloader.py
@@ -83,20 +83,20 @@ async def download_media_to_temp(
     timeout = aiohttp.ClientTimeout(total=max(1, int(timeout_seconds)))
 
     last_err: Exception | None = None
-    for candidate_url in _expand_download_candidates(url):
-        logger.debug(
-            "Media download attempt: origin=%s, candidate=%s, timeout_seconds=%s, proxy_enabled=%s",
-            url,
-            candidate_url,
-            timeout_seconds,
-            bool(proxy),
-        )
-        try:
-            async with aiohttp.ClientSession(
-                timeout=timeout,
-                trust_env=True,
-                connector=build_tls_connector(),
-            ) as session:
+    async with aiohttp.ClientSession(
+        timeout=timeout,
+        trust_env=True,
+        connector=build_tls_connector(),
+    ) as session:
+        for candidate_url in _expand_download_candidates(url):
+            logger.debug(
+                "Media download attempt: origin=%s, candidate=%s, timeout_seconds=%s, proxy_enabled=%s",
+                url,
+                candidate_url,
+                timeout_seconds,
+                bool(proxy),
+            )
+            try:
                 async with session.get(
                     candidate_url,
                     proxy=proxy or None,
@@ -121,33 +121,33 @@ async def download_media_to_temp(
                             f"download failed: empty response, url={candidate_url}"
                         )
 
-            fd, tmp_name = tempfile.mkstemp(
-                prefix="rsshub_media_",
-                suffix=_guess_suffix(candidate_url),
-            )
-            try:
-                with os.fdopen(fd, "wb") as fp:
-                    fp.write(data)
-            except Exception:
-                Path(tmp_name).unlink(missing_ok=True)
-                raise
-            logger.debug(
-                "Media download success: origin=%s, candidate=%s, bytes=%s, tmp=%s",
-                url,
-                candidate_url,
-                len(data),
-                tmp_name,
-            )
-            return Path(tmp_name)
-        except Exception as ex:
-            last_err = ex
-            logger.warning(
-                "Media download attempt failed: origin=%s, candidate=%s, err_type=%s, err=%r",
-                url,
-                candidate_url,
-                type(ex).__name__,
-                ex,
-            )
+                fd, tmp_name = tempfile.mkstemp(
+                    prefix="rsshub_media_",
+                    suffix=_guess_suffix(candidate_url),
+                )
+                try:
+                    with os.fdopen(fd, "wb") as fp:
+                        fp.write(data)
+                except Exception:
+                    Path(tmp_name).unlink(missing_ok=True)
+                    raise
+                logger.debug(
+                    "Media download success: origin=%s, candidate=%s, bytes=%s, tmp=%s",
+                    url,
+                    candidate_url,
+                    len(data),
+                    tmp_name,
+                )
+                return Path(tmp_name)
+            except Exception as ex:
+                last_err = ex
+                logger.warning(
+                    "Media download attempt failed: origin=%s, candidate=%s, err_type=%s, err=%r",
+                    url,
+                    candidate_url,
+                    type(ex).__name__,
+                    ex,
+                )
 
     if last_err is not None:
         raise RuntimeError(

--- a/notifier/senders/media_paths.py
+++ b/notifier/senders/media_paths.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+def resolve_local_file_path(file_value: str) -> str | None:
+    if not file_value or not isinstance(file_value, str):
+        return None
+    if not file_value.startswith("file:///"):
+        return None
+    parsed = urlparse(file_value)
+    if parsed.scheme != "file":
+        return None
+    local_path = unquote(parsed.path or "")
+    if local_path.startswith("/") and len(local_path) >= 3 and local_path[2] == ":":
+        local_path = local_path[1:]
+    return local_path or None
+
+
+def normalize_local_media_file_value(file_value: str) -> str:
+    local_path = resolve_local_file_path(file_value) or file_value
+    return str(Path(local_path).resolve())

--- a/notifier/senders/qq_official.py
+++ b/notifier/senders/qq_official.py
@@ -34,7 +34,9 @@ class QQOfficialMessageSender(MessageSender):
         return local_path or None
 
     @classmethod
-    def _log_media_component_file_check(cls, component: object, session_id: str) -> None:
+    def _log_media_component_file_check(
+        cls, component: object, session_id: str
+    ) -> None:
         file_value = str(getattr(component, "file", "") or "")
         local_path = cls._resolve_local_file_path(file_value)
         resolved_path = local_path or file_value
@@ -68,7 +70,9 @@ class QQOfficialMessageSender(MessageSender):
         )
 
     @classmethod
-    def _normalize_media_component_file(cls, component: object, session_id: str) -> None:
+    def _normalize_media_component_file(
+        cls, component: object, session_id: str
+    ) -> None:
         if not isinstance(component, (Image, Video, File, Record)):
             return
         file_value = str(getattr(component, "file", "") or "")
@@ -146,7 +150,6 @@ class QQOfficialMessageSender(MessageSender):
         cls._log_chain_media_files(chain, session_id)
         return cls._sanitize_nonexistent_local_media(chain, session_id)
 
-
     @classmethod
     def _normalize_chain_media_files(cls, chain: list, session_id: str) -> list:
         for component in chain:
@@ -223,7 +226,9 @@ class QQOfficialMessageSender(MessageSender):
                         session_id,
                     )
                     if missing_sources:
-                        message = cls._append_failed_media_links(message, missing_sources)
+                        message = cls._append_failed_media_links(
+                            message, missing_sources
+                        )
                     if not prepared_chain:
                         continue
                     video_result = await cls._send_chain(session_id, prepared_chain)
@@ -252,7 +257,9 @@ class QQOfficialMessageSender(MessageSender):
                 )
                 if missing_sources:
                     message = cls._append_failed_media_links(message, missing_sources)
-                    prepared_chain = [c for c in prepared_chain if not isinstance(c, Plain)]
+                    prepared_chain = [
+                        c for c in prepared_chain if not isinstance(c, Plain)
+                    ]
                     if message:
                         prepared_chain.append(Plain(message))
                 if not prepared_chain:
@@ -267,7 +274,9 @@ class QQOfficialMessageSender(MessageSender):
                         session_id,
                     )
                     if missing_sources:
-                        message = cls._append_failed_media_links(message, missing_sources)
+                        message = cls._append_failed_media_links(
+                            message, missing_sources
+                        )
                     if not prepared_chain:
                         continue
                     img_result = await cls._send_chain(session_id, prepared_chain)
@@ -294,7 +303,9 @@ class QQOfficialMessageSender(MessageSender):
                         session_id,
                     )
                     if missing_sources:
-                        message = cls._append_failed_media_links(message, missing_sources)
+                        message = cls._append_failed_media_links(
+                            message, missing_sources
+                        )
                         prepared_text_chain = [
                             c for c in prepared_text_chain if not isinstance(c, Plain)
                         ]
@@ -318,7 +329,9 @@ class QQOfficialMessageSender(MessageSender):
                 )
                 if missing_sources:
                     message = cls._append_failed_media_links(message, missing_sources)
-                    prepared_chain = [c for c in prepared_chain if not isinstance(c, Plain)]
+                    prepared_chain = [
+                        c for c in prepared_chain if not isinstance(c, Plain)
+                    ]
                     if message:
                         prepared_chain.append(Plain(message))
                 if not prepared_chain:

--- a/notifier/senders/qq_official.py
+++ b/notifier/senders/qq_official.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from urllib.parse import unquote, urlparse
 
 from astrbot.api import logger
 from astrbot.api.message_components import File, Image, Plain, Record, Video
 
 from .base import MessageSender
+from .media_paths import normalize_local_media_file_value, resolve_local_file_path
 from .types import NotifierContext, PreparedMedia, SendResult
 
 
@@ -19,24 +19,10 @@ class QQOfficialMessageSender(MessageSender):
     - Video: send video first, then send text description separately
     """
 
-    @staticmethod
-    def _resolve_local_file_path(file_value: str) -> str | None:
-        if not file_value or not isinstance(file_value, str):
-            return None
-        if not file_value.startswith("file:///"):
-            return None
-        parsed = urlparse(file_value)
-        if parsed.scheme != "file":
-            return None
-        local_path = unquote(parsed.path or "")
-        if local_path.startswith("/") and len(local_path) >= 3 and local_path[2] == ":":
-            local_path = local_path[1:]
-        return local_path or None
-
     @classmethod
     def _log_media_component_file_check(cls, component: object, session_id: str) -> None:
         file_value = str(getattr(component, "file", "") or "")
-        local_path = cls._resolve_local_file_path(file_value)
+        local_path = resolve_local_file_path(file_value)
         resolved_path = local_path or file_value
         if not resolved_path:
             return
@@ -76,9 +62,8 @@ class QQOfficialMessageSender(MessageSender):
             return
         if file_value.startswith(("http://", "https://", "base64://")):
             return
-        local_path = cls._resolve_local_file_path(file_value) or file_value
         try:
-            resolved = str(Path(local_path).resolve())
+            resolved = normalize_local_media_file_value(file_value)
             if resolved != file_value:
                 component.file = resolved
                 logger.debug(
@@ -116,7 +101,7 @@ class QQOfficialMessageSender(MessageSender):
             if file_value.startswith(("http://", "https://", "base64://")):
                 sanitized.append(component)
                 continue
-            resolved_candidate = cls._resolve_local_file_path(file_value) or file_value
+            resolved_candidate = resolve_local_file_path(file_value) or file_value
             try:
                 exists = Path(resolved_candidate).exists()
             except Exception:

--- a/notifier/senders/qq_official.py
+++ b/notifier/senders/qq_official.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
 from astrbot.api import logger
-from astrbot.api.message_components import Image, Plain, Video
+from astrbot.api.message_components import File, Image, Plain, Record, Video
 
 from .base import MessageSender
 from .types import NotifierContext, PreparedMedia, SendResult
@@ -15,6 +18,146 @@ class QQOfficialMessageSender(MessageSender):
     - Multiple images: send images one by one, then send text separately
     - Video: send video first, then send text description separately
     """
+
+    @staticmethod
+    def _resolve_local_file_path(file_value: str) -> str | None:
+        if not file_value or not isinstance(file_value, str):
+            return None
+        if not file_value.startswith("file:///"):
+            return None
+        parsed = urlparse(file_value)
+        if parsed.scheme != "file":
+            return None
+        local_path = unquote(parsed.path or "")
+        if local_path.startswith("/") and len(local_path) >= 3 and local_path[2] == ":":
+            local_path = local_path[1:]
+        return local_path or None
+
+    @classmethod
+    def _log_media_component_file_check(cls, component: object, session_id: str) -> None:
+        file_value = str(getattr(component, "file", "") or "")
+        local_path = cls._resolve_local_file_path(file_value)
+        resolved_path = local_path or file_value
+        if not resolved_path:
+            return
+        if isinstance(component, str):
+            return
+        if isinstance(component, (Plain,)):
+            return
+        if file_value.startswith(("http://", "https://", "base64://")):
+            return
+        try:
+            exists = Path(resolved_path).exists()
+        except Exception as ex:
+            logger.warning(
+                "QQOfficial media path check failed: session=%s, component=%s, file=%s, resolved=%s, err=%s",
+                session_id,
+                type(component).__name__,
+                file_value,
+                resolved_path,
+                ex,
+            )
+            return
+        logger.debug(
+            "QQOfficial media path check: session=%s, component=%s, file=%s, resolved=%s, exists=%s",
+            session_id,
+            type(component).__name__,
+            file_value,
+            resolved_path,
+            exists,
+        )
+
+    @classmethod
+    def _normalize_media_component_file(cls, component: object, session_id: str) -> None:
+        if not isinstance(component, (Image, Video, File, Record)):
+            return
+        file_value = str(getattr(component, "file", "") or "")
+        if not file_value:
+            return
+        if file_value.startswith(("http://", "https://", "base64://")):
+            return
+        local_path = cls._resolve_local_file_path(file_value) or file_value
+        try:
+            resolved = str(Path(local_path).resolve())
+            if resolved != file_value:
+                component.file = resolved
+                logger.debug(
+                    "QQOfficial media file normalized: session=%s, component=%s, original=%s, normalized=%s",
+                    session_id,
+                    type(component).__name__,
+                    file_value,
+                    resolved,
+                )
+        except Exception as ex:
+            logger.warning(
+                "QQOfficial media file normalize failed: session=%s, component=%s, file=%s, err=%s",
+                session_id,
+                type(component).__name__,
+                file_value,
+                ex,
+            )
+
+    @classmethod
+    def _sanitize_nonexistent_local_media(
+        cls,
+        chain: list,
+        session_id: str,
+    ) -> tuple[list, list[str]]:
+        sanitized: list = []
+        missing_sources: list[str] = []
+        for component in chain:
+            if isinstance(component, Plain):
+                sanitized.append(component)
+                continue
+            file_value = str(getattr(component, "file", "") or "")
+            if not file_value:
+                sanitized.append(component)
+                continue
+            if file_value.startswith(("http://", "https://", "base64://")):
+                sanitized.append(component)
+                continue
+            resolved_candidate = cls._resolve_local_file_path(file_value) or file_value
+            try:
+                exists = Path(resolved_candidate).exists()
+            except Exception:
+                exists = False
+            if exists:
+                sanitized.append(component)
+                continue
+            source_for_fallback = str(getattr(component, "url", "") or file_value)
+            missing_sources.append(source_for_fallback)
+            logger.warning(
+                "QQOfficial media dropped before send: session=%s, component=%s, file=%s, resolved=%s, fallback=%s",
+                session_id,
+                type(component).__name__,
+                file_value,
+                resolved_candidate,
+                source_for_fallback,
+            )
+        return sanitized, missing_sources
+
+    @classmethod
+    def _prepare_chain_for_send(
+        cls,
+        chain: list,
+        session_id: str,
+    ) -> tuple[list, list[str]]:
+        cls._normalize_chain_media_files(chain, session_id)
+        cls._log_chain_media_files(chain, session_id)
+        return cls._sanitize_nonexistent_local_media(chain, session_id)
+
+
+    @classmethod
+    def _normalize_chain_media_files(cls, chain: list, session_id: str) -> list:
+        for component in chain:
+            cls._normalize_media_component_file(component, session_id)
+        return chain
+
+    @classmethod
+    def _log_chain_media_files(cls, chain: list, session_id: str) -> None:
+        for component in chain:
+            if isinstance(component, (Image, Video)):
+                cls._log_media_component_file_check(component, session_id)
 
     @classmethod
     async def send_to_user(
@@ -75,7 +218,15 @@ class QQOfficialMessageSender(MessageSender):
             # 1. Send video first if exists (video + text in one chain)
             if has_video:
                 for video in video_components:
-                    video_result = await cls._send_chain(session_id, [video])
+                    prepared_chain, missing_sources = cls._prepare_chain_for_send(
+                        [video],
+                        session_id,
+                    )
+                    if missing_sources:
+                        message = cls._append_failed_media_links(message, missing_sources)
+                    if not prepared_chain:
+                        continue
+                    video_result = await cls._send_chain(session_id, prepared_chain)
                     if not video_result.ok:
                         logger.warning(
                             "QQOfficial video send failed: session=%s, err=%s",
@@ -95,12 +246,31 @@ class QQOfficialMessageSender(MessageSender):
                 if message:
                     chain.append(Plain(message))
                 chain.extend(tail_components)
-                return await cls._send_chain(session_id, chain)
+                prepared_chain, missing_sources = cls._prepare_chain_for_send(
+                    chain,
+                    session_id,
+                )
+                if missing_sources:
+                    message = cls._append_failed_media_links(message, missing_sources)
+                    prepared_chain = [c for c in prepared_chain if not isinstance(c, Plain)]
+                    if message:
+                        prepared_chain.append(Plain(message))
+                if not prepared_chain:
+                    return SendResult(ok=False, detail="empty_message")
+                return await cls._send_chain(session_id, prepared_chain)
 
             elif total_images > 1:
                 # Multiple images: send one by one
                 for img in image_components:
-                    img_result = await cls._send_chain(session_id, [img])
+                    prepared_chain, missing_sources = cls._prepare_chain_for_send(
+                        [img],
+                        session_id,
+                    )
+                    if missing_sources:
+                        message = cls._append_failed_media_links(message, missing_sources)
+                    if not prepared_chain:
+                        continue
+                    img_result = await cls._send_chain(session_id, prepared_chain)
                     if not img_result.ok:
                         logger.warning(
                             "QQOfficial image send failed: session=%s, err=%s",
@@ -119,7 +289,20 @@ class QQOfficialMessageSender(MessageSender):
                     if message:
                         text_chain.append(Plain(message))
                     text_chain.extend(tail_components)
-                    return await cls._send_chain(session_id, text_chain)
+                    prepared_text_chain, missing_sources = cls._prepare_chain_for_send(
+                        text_chain,
+                        session_id,
+                    )
+                    if missing_sources:
+                        message = cls._append_failed_media_links(message, missing_sources)
+                        prepared_text_chain = [
+                            c for c in prepared_text_chain if not isinstance(c, Plain)
+                        ]
+                        if message:
+                            prepared_text_chain.append(Plain(message))
+                    if not prepared_text_chain:
+                        return SendResult(ok=True)
+                    return await cls._send_chain(session_id, prepared_text_chain)
 
                 return SendResult(ok=True)
 
@@ -129,16 +312,27 @@ class QQOfficialMessageSender(MessageSender):
                 if message:
                     chain.append(Plain(message))
                 chain.extend(tail_components)
-                if not chain:
+                prepared_chain, missing_sources = cls._prepare_chain_for_send(
+                    chain,
+                    session_id,
+                )
+                if missing_sources:
+                    message = cls._append_failed_media_links(message, missing_sources)
+                    prepared_chain = [c for c in prepared_chain if not isinstance(c, Plain)]
+                    if message:
+                        prepared_chain.append(Plain(message))
+                if not prepared_chain:
                     return SendResult(ok=False, detail="empty_message")
-                return await cls._send_chain(session_id, chain)
+                return await cls._send_chain(session_id, prepared_chain)
 
         except Exception as err:
-            err_text = str(err)
+            err_text = repr(err)
             logger.warning(
-                "QQOfficial send failed: session=%s, err=%s",
+                "QQOfficial send failed: session=%s, err_type=%s, err=%r",
                 session_id,
+                type(err).__name__,
                 err,
+                exc_info=True,
             )
 
             # Fallback: convert media to links in text

--- a/notifier/senders/weixin_oc.py
+++ b/notifier/senders/weixin_oc.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from astrbot.api import logger
+from astrbot.api.message_components import Plain
+
+from .base import MessageSender
+from .types import NotifierContext, PreparedMedia, SendResult
+
+
+class WeixinOCMessageSender(MessageSender):
+    """Weixin personal sender: send one message component per request."""
+
+    @classmethod
+    async def _send_components_sequentially(
+        cls,
+        session_id: str,
+        components: list,
+    ) -> SendResult:
+        for component in components:
+            result = await cls._send_chain(session_id, [component])
+            if not result.ok:
+                return result
+        return SendResult(ok=True)
+
+    @classmethod
+    async def send_to_user(
+        cls,
+        session_id: str,
+        message: str,
+        media: list[tuple[str, str]] | None = None,
+        prepared_media: list[PreparedMedia] | None = None,
+        context: NotifierContext | None = None,
+    ) -> SendResult:
+        logger.debug(
+            "WeixinOC sender strategy: sequential single-component send, session=%s, has_media=%s, prepared_media=%s",
+            session_id,
+            bool(media),
+            bool(prepared_media),
+        )
+
+        try:
+            effective_prepared = prepared_media
+            if effective_prepared is None and media:
+                effective_prepared = await cls.prepare_media(media)
+
+            image_components = []
+            tail_components = []
+            failed_media_urls: list[str] = []
+
+            if effective_prepared:
+                (
+                    image_components,
+                    tail_components,
+                    failed_media_urls,
+                ) = await cls._build_media_components(effective_prepared)
+
+            message = cls._append_failed_media_links(message, failed_media_urls)
+
+            if image_components:
+                media_result = await cls._send_components_sequentially(
+                    session_id,
+                    image_components,
+                )
+                if not media_result.ok:
+                    logger.warning(
+                        "WeixinOC image/video send failed: session=%s, detail=%s",
+                        session_id,
+                        media_result.detail,
+                    )
+                    return media_result
+
+            if tail_components:
+                tail_result = await cls._send_components_sequentially(
+                    session_id,
+                    tail_components,
+                )
+                if not tail_result.ok:
+                    logger.warning(
+                        "WeixinOC tail media send failed: session=%s, detail=%s",
+                        session_id,
+                        tail_result.detail,
+                    )
+                    return tail_result
+
+            if message:
+                return await cls._send_chain(session_id, [Plain(message)])
+
+            if image_components or tail_components:
+                return SendResult(ok=True)
+
+            return SendResult(ok=False, detail="empty_message")
+
+        except Exception as err:
+            logger.warning(
+                "WeixinOC send failed: session=%s, err_type=%s, err=%r",
+                session_id,
+                type(err).__name__,
+                err,
+                exc_info=True,
+            )
+            fallback_text = cls._append_failed_media_links(
+                message,
+                [url for _, url in media] if media else [],
+            )
+            try:
+                if fallback_text:
+                    fallback_result = await cls._send_chain(
+                        session_id,
+                        [Plain(fallback_text)],
+                    )
+                    if fallback_result.ok:
+                        return SendResult(
+                            ok=True,
+                            transient=False,
+                            detail="weixin_oc_failed_text_fallback",
+                        )
+                    return fallback_result
+            except Exception as fallback_ex:
+                return SendResult(
+                    ok=False,
+                    transient=cls._is_transient_network_error(fallback_ex),
+                    detail=str(fallback_ex),
+                )
+
+            return SendResult(
+                ok=False,
+                transient=cls._is_transient_network_error(err),
+                detail=str(err),
+            )

--- a/utils/config.py
+++ b/utils/config.py
@@ -28,13 +28,18 @@ class PluginConfig:
     failed_queue_max_retries: int = 3
     sender_strategies: dict = None
     deduplicate_multi_bot: bool = True
+    bootstrap_skip_history: bool = True
     platform_shared_data: dict = None
     db_file: str = "rsshub.db"
     astrbot_config: AstrBotConfig | None = None
 
     def __post_init__(self):
         if self.sender_strategies is None:
-            self.sender_strategies = {"telegram": True, "aiocqhttp": True}
+            self.sender_strategies = {
+                "telegram": True,
+                "aiocqhttp": True,
+                "weixin_oc": True,
+            }
         if self.platform_shared_data is None:
             self.platform_shared_data = {"aiocqhttp": False}
 
@@ -74,10 +79,14 @@ class PluginConfig:
             config.sender_strategies = {
                 "telegram": bool(raw_strategies.get("telegram", True)),
                 "aiocqhttp": bool(raw_strategies.get("aiocqhttp", True)),
+                "weixin_oc": bool(raw_strategies.get("weixin_oc", True)),
             }
             # Load multi-bot deduplication
             config.deduplicate_multi_bot = bool(
                 astrbot_config.get("deduplicate_multi_bot", True)
+            )
+            config.bootstrap_skip_history = bool(
+                astrbot_config.get("bootstrap_skip_history", True)
             )
             # Load platform shared data
             raw_shared = astrbot_config.get("platform_shared_data", {})
@@ -112,10 +121,14 @@ class PluginConfig:
                 config.sender_strategies = {
                     "telegram": bool(raw_strategies.get("telegram", True)),
                     "aiocqhttp": bool(raw_strategies.get("aiocqhttp", True)),
+                    "weixin_oc": bool(raw_strategies.get("weixin_oc", True)),
                 }
                 # Load multi-bot deduplication
                 config.deduplicate_multi_bot = bool(
                     data.get("deduplicate_multi_bot", True)
+                )
+                config.bootstrap_skip_history = bool(
+                    data.get("bootstrap_skip_history", True)
                 )
                 # Load platform shared data
                 raw_shared = data.get("platform_shared_data", {})
@@ -147,6 +160,9 @@ class PluginConfig:
         )
         self.astrbot_config["sender_strategies"] = dict(self.sender_strategies)
         self.astrbot_config["deduplicate_multi_bot"] = bool(self.deduplicate_multi_bot)
+        self.astrbot_config["bootstrap_skip_history"] = bool(
+            self.bootstrap_skip_history
+        )
         self.astrbot_config["platform_shared_data"] = dict(self.platform_shared_data)
         self.astrbot_config.save_config()
 
@@ -167,6 +183,8 @@ class PluginConfig:
             return self.sender_strategies.get("telegram", True)
         if key == "sender_strategy_aiocqhttp":
             return self.sender_strategies.get("aiocqhttp", True)
+        if key == "sender_strategy_weixin_oc":
+            return self.sender_strategies.get("weixin_oc", True)
         # Handle platform_shared_data_* keys
         if key == "platform_shared_data_aiocqhttp":
             return self.platform_shared_data.get("aiocqhttp", False)
@@ -181,6 +199,10 @@ class PluginConfig:
             return
         if key == "sender_strategy_aiocqhttp":
             self.sender_strategies["aiocqhttp"] = bool(value)
+            self.save()
+            return
+        if key == "sender_strategy_weixin_oc":
+            self.sender_strategies["weixin_oc"] = bool(value)
             self.save()
             return
         # Handle platform_shared_data_* keys


### PR DESCRIPTION
## Summary by Sourcery

引入微信个人号发送策略，提升媒体处理的健壮性，并增强订阅源监控的去重能力与可观测性。

New Features:
- 新增专用的微信个人号（`weixin_oc`）消息发送器，每次请求按组件逐个发送，并支持文本与媒体的回退策略。
- 通过新的 `sender_strategy_weixin_oc` 标志使微信个人号发送器可配置，并通过配置命令与帮助文本对其进行暴露。
- 新增 `bootstrap_skip_history` 配置项，用于控制首次轮询时仅初始化历史记录，还是同时推送历史条目。

Bug Fixes:
- 修复在容器化环境中，由于本地文件路径解析错误导致 QQ 公众号媒体发送失败的问题。
- 修复通知队列容量检查：现在当队列“达到”配置上限时即视为已满，而不是“超过”上限才视为已满。

Enhancements:
- 在各发送器中规范化并校验本地媒体文件路径，对不存在的本地媒体进行丢弃，同时在可能的情况下将其链接追加到文本中。
- 改进媒体下载逻辑，支持带包装的 URL 参数、多候选重试，并增加缓存与下载的详细日志。
- 优化订阅条目去重策略，采用以稳定身份为优先的哈希方式，并在上游兼容的回退方案之间切换，从而减少因内容细微变化导致的重复推送。
- 扩展通知失败处理逻辑，增加入队、丢弃、重试以及重试耗尽等详细统计信息，并在订阅轮询日志中展示这些指标。

Documentation:
- 更新 README 和变更日志，记录新的微信发送策略、`bootstrap_skip_history` 行为、配置标志以及监控方面的限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a Weixin personal account sender strategy, improve media handling robustness, and enhance feed monitoring deduplication and observability.

New Features:
- Add a dedicated Weixin personal (weixin_oc) message sender that sends one component per request with text and media fallback behavior.
- Make the Weixin personal sender configurable via a new sender_strategy_weixin_oc flag and expose it through config commands and help text.
- Add a bootstrap_skip_history configuration option to control whether the first polling round only initializes history or also pushes historical entries.

Bug Fixes:
- Prevent QQ Official media sends from failing due to incorrectly resolved local file paths in containerized environments.
- Fix failed notification queue capacity checks so the queue is considered full when it reaches, not exceeds, the configured limit.

Enhancements:
- Normalize and validate local media file paths across senders, dropping nonexistent local media while appending their links into text when possible.
- Improve media downloading by supporting wrapped URL parameters, retrying multiple candidates, and adding detailed cache and download logging.
- Refine feed entry deduplication using stable identity-first hashing with upstream-compatible fallbacks to reduce duplicate pushes from minor content changes.
- Extend notifier failure handling with detailed statistics on enqueue, drops, retries, and exhausted failures, and surface these metrics in feed polling logs.

Documentation:
- Update README and changelog to document the new Weixin sender strategy, bootstrap_skip_history behavior, configuration flags, and monitoring limitations.

</details>