### PR TITLE
fix: remove image limit during RSS feed push to handle sources with many images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.2] - 2026-04-26
+
+### Fixed
+
+- **移除推送时图片上限**：
+  - 解决 RSS 源包含大量图片时只推送 9-14 张的问题
+
+<details>
+<summary>历史更新记录</summary>
+
 ## [1.1.1] - 2026-04-26
 
 ### Fixed
@@ -122,8 +132,6 @@
 
 ---
 
-<details>
-<summary>历史更新记录</summary>
 
 ### Refactored
 

--- a/commands/subscription_cmd.py
+++ b/commands/subscription_cmd.py
@@ -916,8 +916,6 @@ async def batch_activate_subs(
 
     from ..db import Sub, get_session
 
-    from sqlmodel import or_
-
     async with get_session() as session:
         # 查询当前会话中该用户的所有订阅（当前禁用的），预加载 feed
         # 处理 target_session 为 NULL 的情况（NULL 视为当前会话）

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_rsshub
 display_name: RSS订阅
 desc: 多平台RSS订阅推送插件，支持失败队列重试、多BOT去重、平台数据共享、智能发送策略，LLM工具调用，让你的BOT成为信息聚合中心。
-version: v1.1.1
+version: v1.1.2
 author: FlanChanXwO
 repo: https://github.com/FlanChanXwO/astrbot_plugin_rsshub

--- a/notifier/senders/base.py
+++ b/notifier/senders/base.py
@@ -183,7 +183,6 @@ class MessageSender:
         image_components = []
         tail_components = []
         failed_media_urls: list[str] = []
-        image_count = 0
 
         for item in prepared_media:
             media_type = item.media_type
@@ -237,7 +236,6 @@ class MessageSender:
                 image_components.append(
                     Image(file=media_file_value, url=image_url_value)
                 )
-                image_count += 1
             elif media_type == "video":
                 if cls._is_video_transcode_enabled() and local_path:
                     try:

--- a/notifier/senders/base.py
+++ b/notifier/senders/base.py
@@ -233,13 +233,6 @@ class MessageSender:
             media_file_value = local_file_uri if local_path else media_url
 
             if media_type == "image":
-                if image_count >= 9:
-                    logger.warning(
-                        "Image skipped due to limit: url=%s, count=%s",
-                        media_url,
-                        image_count,
-                    )
-                    continue
                 image_url_value = "" if local_path else media_url
                 image_components.append(
                     Image(file=media_file_value, url=image_url_value)


### PR DESCRIPTION
## Summary by Sourcery

移除为 RSS 源通知构建媒体组件时的图片数量限制，并提升插件版本。

Bug Fixes:
- 确保来自 RSS 源的所有图片都会被推送，而不是被限制为最多 9 张。

Documentation:
- 在更新日志中添加 1.1.2 条目，描述图片数量限制修复内容。

Chores:
- 将插件元数据版本号从 v1.1.1 提升到 v1.1.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the image count limit when building media components for RSS feed notifications and bump the plugin version.

Bug Fixes:
- Ensure all images from RSS sources are pushed instead of being capped at 9 images.

Documentation:
- Update changelog with a 1.1.2 entry describing the image limit fix.

Chores:
- Bump plugin metadata version from v1.1.1 to v1.1.2.

</details>