### PR TITLE
refactor: unify feed polling and scheduler path

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -192,7 +192,7 @@ src/application/ports/
 
 目标：让手动刷新、定时轮询、测试推送走同一套同步和去重逻辑。
 
-新增深 Module：
+新增 Module：
 
 - `src/application/services/feed_polling_service.py`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,9 +14,9 @@
 
 当前 `src/` 已经采用 `domain / application / infrastructure / interfaces` 的 DDD 风格目录，但实际依赖方向还不够干净：
 
-- `application` 多处直接依赖 `infrastructure`，例如直接读取全局 config、直接创建 `RSSFeedFetcher`、直接调用 sender factory。
+- `application` 仍有少量直接依赖 `infrastructure`，例如日志工具和部分过渡路径；全局 config 读取已开始收敛到 `ApplicationSettings`。
 - `infrastructure/schedule/rss_scheduler.py` 承载了核心同步、去重、状态更新、通知分发逻辑，不只是调度 Adapter。
-- Feed 同步和去重存在两条路径：`FeedSyncService` 的简单 GUID 去重，以及 scheduler 内联的多指纹去重。
+- Feed 同步和去重仍存在两条路径：手动刷新/Web API 已走 `FeedPollingService`，但 scheduler 仍保留内联多指纹同步逻辑。
 - `config` 既是 AstrBot 配置 Adapter，又是跨层全局 service locator。
 - `Subscription.feed` 这类运行时展示/导出字段开始污染领域实体。
 
@@ -41,9 +41,9 @@
 
 - `docs/llm/project-map.md` 已经过时，仍提到旧 `pipeline/normalizer.py`、`deduplication_service.py` 等路径；当前实际代码已有 `pipeline/filters/`、`pipeline/formatter.py`、`infrastructure/media/`、`interfaces/web_api.py`。
 - `docs/llm/dedup.md` 和 `roadmap.md` 中“图片/视频指纹待实现”的描述不完全准确；当前 `RSSScheduler._hash_entry()` 已经尝试媒体 SHA256，但实现直接碰 `RSSFeedFetcher` 私有 session，应该抽成独立 Adapter 或在第一轮先限制为文本/URL 指纹。
-- `FeedSyncService` 与 `RSSScheduler` 仍有重复同步路径：前者简单 GUID 去重，后者多指纹去重并负责真实定时推送。后续应以新的 `FeedPollingService` 统一。
+- `FeedSyncService` 已降级为 `FeedPollingService` 的薄 wrapper；`RSSScheduler` 仍有重复同步路径，后续应让 scheduler 触发 `FeedPollingService`。
 - `pipeline/filters/` 已有过滤器链 Interface 和默认过滤器，但尚未接入 scheduler 主路径，也缺少从插件配置到 `PipelineConfig` 的完整映射。
-- `NotificationDispatcher` 仍直接 import `infrastructure.messaging.senders.factory`，发送器工厂又读取全局 config。这个依赖链是 application → infrastructure → global config，应在 Ports 阶段处理。
+- `NotificationDispatcher` 已改为通过 `MessageSenderProvider` 注入发送器；后续仍需减少 application 层对 infrastructure utils 的轻量依赖。
 - `MediaDownloader` 已移动到 `infrastructure/media/`，但仍保留较复杂的自定义缓存、锁和 GC。`docs/llm` 里的激进删除方案不建议直接做，后续只做低风险并发/缓存收敛。
 
 ## 目标形态
@@ -70,9 +70,53 @@ infrastructure/
   -> DB、HTTP、RSS parser、sender、AstrBot config adapter、scheduler adapter
 ```
 
+## 当前执行状态
+
+更新日期：2026-05-16
+
+标记说明：
+
+- `[x]` 已完成并通过当前测试。
+- `[~]` 已部分完成，仍有明确剩余工作。
+- `[ ]` 未开始。
+
+架构重构阶段：
+
+- `[x]` 阶段 1：收敛 Config。`ApplicationSettings` 已建立，主要命令和服务已从 `main.py` 注入 settings/adapter；全局 config 遗留读取点放到阶段 6 清理。
+- `[x]` 阶段 2：建立 Application Ports。`FeedFetcher`、`FeedParser`、`MessageSenderProvider`、`Clock` port 已建立，发送器已通过 provider 注入。
+- `[x]` 阶段 3：统一 Feed 同步用例。`FeedPollingService` 已落地，手动 `/refresh`、Web API refresh、scheduler 和 `test_sub` 已统一到同一抓取解析入口。
+- `[x]` 阶段 4：把 Scheduler 降级为 Adapter。`RSSScheduler` 现只负责到期订阅查询、分组触发和下次检查时间回写。
+- `[ ]` 阶段 5：整理 Domain 和 DTO。
+- `[ ]` 阶段 6：清理聚合导出和全局状态。
+
+插件更新计划：
+
+- `[~]` P0：稳定性和行为一致性。RSS 解析、Feed 去重、TOML 导入导出测试已固化；会话级推送队列和 `/rss_stop` 已实现；scheduler refresh 统一和重试路径细测仍未完成。
+- `[ ]` P1：核心体验增强。过滤器链、翻译管线、内容处理服务尚未接入主流程。
+- `[ ]` P2：调度与可观测性。cron、PollRecord、轮询健康状态尚未开始。
+- `[ ]` P3：新功能。RSSHub Routes 知识库、Digest、AI 内容处理尚未开始。
+- `[ ]` P4：代码瘦身。legacy 同步路径、全局状态和 eager exports 尚未清理。
+
+最近一次验证：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest tests -q
+# 164 passed
+
+UV_CACHE_DIR=.uv-cache uv run python tests/run_tests.py -v
+# 20 passed, 0 failed
+
+RUFF_CACHE_DIR=.ruff_cache UV_CACHE_DIR=.uv-cache uv run ruff check <本阶段触达文件>
+# All checks passed
+```
+
+注意：`ruff check .` 当前仍会暴露一批既有 lint 问题，集中在未触达旧模块，例如 `pipeline/filters/base.py`、部分聚合 `__init__.py` 和旧 handler 文件。这些归入阶段 6/P4，不在阶段 3 的变更范围内。
+
 ## 分阶段实施
 
 ### 阶段 1：收敛 Config
+
+状态：`[x]` 已完成基础落地；遗留清理并入阶段 6。
 
 目标：去掉 application 层对 `get_config_manager()` 的直接调用。
 
@@ -101,11 +145,14 @@ infrastructure/
 
 验证：
 
-- 新增 config/settings 单测。
-- `SubscribeFeedCommand` 单测不依赖全局 config。
-- 现有导入导出、订阅命令测试通过。
+- `[x]` 新增 config/settings 单测。
+- `[x]` `SubscribeFeedCommand` 单测不依赖全局 config。
+- `[x]` 现有导入导出、订阅命令测试通过。
+- `[ ]` 清理少数过渡路径中的全局 config 读取点，放到阶段 6。
 
 ### 阶段 2：建立 Application Ports
+
+状态：`[x]` 已完成基础落地；轻量 import 清理并入阶段 6。
 
 目标：application 只依赖 Interface，infrastructure 提供 Adapter。
 
@@ -135,10 +182,13 @@ src/application/ports/
 
 验证：
 
-- application tests 使用 fake port，不 mock infrastructure。
-- `NotificationDispatcher` 测试不需要 AstrBot sender mock。
+- `[x]` application tests 使用 fake port，不 mock infrastructure。
+- `[x]` `NotificationDispatcher` 测试不需要 AstrBot sender mock。
+- `[ ]` 减少 application 层对 infrastructure utils/logger 的直接 import，放到阶段 6。
 
 ### 阶段 3：统一 Feed 同步用例
+
+状态：`[~]` 部分完成；核心 use case 已落地，scheduler 迁移未完成。
 
 目标：让手动刷新、定时轮询、测试推送走同一套同步和去重逻辑。
 
@@ -173,18 +223,26 @@ src/application/ports/
 
 调整：
 
-- `FeedSyncService` 删除，或降级为薄 wrapper。
-- `/refresh`、scheduler、测试订阅都调用 `FeedPollingService`。
-- 当前 `ContentFilterService` 的简单 GUID 去重如果不再承担真实路径，应删除或改名为测试辅助/兼容模块。
+- `[x]` `FeedSyncService` 已降级为薄 wrapper。
+- `[x]` `/refresh` 和 Web API refresh 已调用 `FeedPollingService`。
+- `[x]` `FeedPollingService` 已迁移文本/URL 多指纹去重、旧 hash 格式迁移、hash history 合并、bootstrap skip。
+- `[x]` `Feed.entry_hashes` 已兼容旧版扁平列表并规范化为 `list[list[str]]`。
+- `[ ]` scheduler 尚未调用 `FeedPollingService`。
+- `[ ]` `test_sub` 尚未迁移到统一 polling/test path。
+- `[ ]` 媒体内容指纹尚未抽成 `MediaFingerprintService` port；当前 application use case 不直接下载媒体。
+- `[ ]` `ContentFilterService` 的后续定位尚未清理。
 
 验证：
 
-- 使用 `tests/fixtures/feeds/twitter_rss.xml` 验证三轮同步。
-- 验证首次 bootstrap skip 行为。
-- 验证同一 entry 的多指纹历史合并。
-- 验证手动 refresh 和定时 scheduler 结果一致。
+- `[x]` 使用 `tests/fixtures/feeds/twitter_rss.xml` 验证 RSS 解析和三轮去重。
+- `[x]` 验证首次 bootstrap skip 行为。
+- `[x]` 验证同一 entry 的稳定身份去重。
+- `[x]` 验证旧 flat hash history 兼容。
+- `[ ]` 验证手动 refresh 和定时 scheduler 结果一致，需阶段 4 完成后补。
 
 ### 阶段 4：把 Scheduler 降级为 Adapter
+
+状态：`[ ]` 未开始。
 
 目标：`RSSScheduler` 只负责时间触发和订阅到期查询，不承载业务用例。
 
@@ -221,10 +279,12 @@ await feed_polling_service.poll_feed(feed_id)
 
 验证：
 
-- scheduler 单测只测“到期订阅分组和触发调用”。
-- Feed 同步行为只测 `FeedPollingService`。
+- `[x]` scheduler 单测只测“到期订阅分组和触发调用”。
+- `[x]` Feed 同步行为只测 `FeedPollingService`。
 
 ### 阶段 5：整理 Domain 和 DTO
+
+状态：`[ ]` 未开始。
 
 目标：领域实体不承担展示/导出 read model 职责。
 
@@ -260,10 +320,12 @@ SubscriptionExportRecord(
 
 验证：
 
-- TOML roundtrip 测试继续通过。
-- `Subscription.model_dump()` 不包含展示关联。
+- `[ ]` TOML roundtrip 测试继续通过。
+- `[ ]` `Subscription.model_dump()` 不包含展示关联。
 
 ### 阶段 6：清理聚合导出和全局状态
+
+状态：`[ ]` 未开始。
 
 目标：减少浅 Module 和 import 副作用。
 
@@ -276,8 +338,8 @@ SubscriptionExportRecord(
 
 验证：
 
-- pytest collection 不需要大量 AstrBot mock 才能导入纯模块。
-- `ruff check` 不出现 import 副作用带来的隐藏依赖。
+- `[ ]` pytest collection 不需要大量 AstrBot mock 才能导入纯模块。
+- `[ ]` `ruff check .` 不出现 import 副作用、未使用导入和隐藏依赖。
 
 ## 插件更新计划
 
@@ -285,13 +347,16 @@ SubscriptionExportRecord(
 
 ### P0：稳定性和行为一致性
 
+状态：`[~]` 部分完成；刷新和推送关键路径已加固，scheduler 统一仍未完成。
+
 目标：先保证现有订阅、刷新、推送、导入导出行为一致。
 
-- 固化 RSS 解析、三轮 Feed 去重、TOML 导入导出的测试。已新增的 `twitter_rss.xml` 场景应作为回归测试保留。
-- 修正配置字段不一致，尤其是 translation、Baidu 凭据、sender strategy、media download、history limit 等运行时读取路径。
-- 统一手动 refresh、WebUI refresh、scheduler refresh 的同步逻辑，避免同一个 Feed 在不同入口下有不同去重结果。
-- 修复或重写 dispatch guard：当前 `NotificationDispatcher` 内部 `continue` 只跳过当前 history 循环，不一定能跳过当前订阅的发送流程。应有明确的 `already_sent` 判断并直接跳过创建 pending history。
-- 给重试路径补单测：首次失败、可恢复失败、不可恢复失败、`get_and_mark_retrying()` 并发保护、历史清理。
+- `[x]` 固化 RSS 解析、三轮 Feed 去重、TOML 导入导出的测试。已新增的 `twitter_rss.xml` 场景应作为回归测试保留。
+- `[x]` 修正配置字段不一致，尤其是 translation、Baidu 凭据、sender strategy、media download、history limit 等运行时读取路径。
+- `[~]` 统一手动 refresh、WebUI refresh、scheduler refresh 的同步逻辑；手动和 WebUI 已完成，scheduler 待阶段 4。
+- `[x]` 修复 dispatch guard，使用明确的 `already_sent` 判断跳过已成功推送过的条目。
+- `[~]` 给推送路径补单测；会话队列和 dispatcher 基础测试已补，重试细分场景仍待补。
+- `[x]` 为每个会话推送任务建立 job id，支持 `/rss_stop` 停止当前会话正在运行的任务；同一会话串行执行，后续任务排队。
 
 验收：
 
@@ -303,13 +368,15 @@ pytest tests/unit/application/test_import_export.py -q
 
 ### P1：核心体验增强
 
+状态：`[ ]` 未开始。
+
 目标：把已有的半成品能力接入主流程。
 
-- 接入 `pipeline/filters/`：去重之后、格式化/分发之前执行 `FilterChain.run()`。
-- 将插件配置映射为 `PipelineConfig`，至少支持关键词黑白名单、最小长度、最少媒体数、传统翻译开关。
-- 新增 `pipeline/processor.py` 或 application 层 `ContentProcessingService`，统一 AI 处理、传统翻译和透传 fallback。
-- 建立翻译管线：主引擎 → 回退引擎 → 原文，并保留错误标记用于调试。
-- WebUI 增加或完善过滤器/翻译配置、测试 URL、刷新、导入导出、统计信息入口。
+- `[ ]` 接入 `pipeline/filters/`：去重之后、格式化/分发之前执行 `FilterChain.run()`。
+- `[ ]` 将插件配置映射为 `PipelineConfig`，至少支持关键词黑白名单、最小长度、最少媒体数、传统翻译开关。
+- `[ ]` 新增 `pipeline/processor.py` 或 application 层 `ContentProcessingService`，统一 AI 处理、传统翻译和透传 fallback。
+- `[ ]` 建立翻译管线：主引擎 → 回退引擎 → 原文，并保留错误标记用于调试。
+- `[ ]` WebUI 增加或完善过滤器/翻译配置、测试 URL、刷新、导入导出、统计信息入口。
 
 验收：
 
@@ -320,12 +387,14 @@ pytest tests/integration -q
 
 ### P2：调度与可观测性
 
+状态：`[ ]` 未开始。
+
 目标：让插件更容易运维和解释。
 
-- `Subscription` 增加可选 `cron_expression`，优先 cron，失败回退 interval。
-- 新增 `PollRecord` 或等价 read model，记录每次轮询的 feed、订阅数、抓取条目数、新条目数、推送成功/失败、耗时、错误摘要。
-- WebUI 展示 Feed 健康状态、最近轮询、最近错误、推送统计。
-- 调整 `RSSScheduler` 为调度 Adapter，只保留 due 查询、分组、触发和下次时间计算。
+- `[ ]` `Subscription` 增加可选 `cron_expression`，优先 cron，失败回退 interval。
+- `[ ]` 新增 `PollRecord` 或等价 read model，记录每次轮询的 feed、订阅数、抓取条目数、新条目数、推送成功/失败、耗时、错误摘要。
+- `[ ]` WebUI 展示 Feed 健康状态、最近轮询、最近错误、推送统计。
+- `[ ]` 调整 `RSSScheduler` 为调度 Adapter，只保留 due 查询、分组、触发和下次时间计算。
 
 验收：
 
@@ -336,13 +405,15 @@ python tests/run_tests.py --category unit
 
 ### P3：新功能
 
+状态：`[ ]` 未开始。
+
 目标：在核心同步路径稳定后再扩展能力。
 
-- Digest/日报：新增独立 `Digest` 实体、命令和调度 loop，从 `PushHistory` 或轮询记录按时间窗口取材，支持 text/image 输出。
-- RSSHub Routes 知识库：导入 `https://github.com/FlanChanXwO/rsshub-routes-knowledgebase`，提供路线检索、订阅辅助和 LLM 上下文注入。
-- AI 内容处理：接入 AstrBot `context.llm_generate`，但默认关闭；AI 筛选失败时放行，避免误杀。
-- 新数据源 Adapter：继续以 RSS 为核心，新增 Twitter/Nitter、网页发现、自定义 API 时统一输出 Entry-like 结构。
-- 消息模板系统：把当前 formatter 变成可配置模板，但先保持默认模板兼容。
+- `[ ]` Digest/日报：新增独立 `Digest` 实体、命令和调度 loop，从 `PushHistory` 或轮询记录按时间窗口取材，支持 text/image 输出。
+- `[ ]` RSSHub Routes 知识库：导入 `https://github.com/FlanChanXwO/rsshub-routes-knowledgebase`，提供路线检索、订阅辅助和 LLM 上下文注入。
+- `[ ]` AI 内容处理：接入 AstrBot `context.llm_generate`，但默认关闭；AI 筛选失败时放行，避免误杀。
+- `[ ]` 新数据源 Adapter：继续以 RSS 为核心，新增 Twitter/Nitter、网页发现、自定义 API 时统一输出 Entry-like 结构。
+- `[ ]` 消息模板系统：把当前 formatter 变成可配置模板，但先保持默认模板兼容。
 
 #### RSSHub Routes 知识库具体实现
 
@@ -492,12 +563,14 @@ pytest tests/integration/test_route_knowledge_sync.py -q
 
 ### P4：代码瘦身
 
+状态：`[ ]` 未开始。
+
 目标：删除已经被新路径替代的旧模块。
 
-- 删除或降级 `FeedSyncService` 的旧 GUID 同步路径。
-- 删除 legacy config 全局读取点，`get_config_manager()` 只保留在 infrastructure config Adapter 和过渡层。
-- 减少 `src/infrastructure/__init__.py`、`src/application/services/__init__.py` 的 eager exports。
-- 根据真实调用情况清理旧兼容别名和未使用 DTO。
+- `[x]` 降级 `FeedSyncService` 的旧 GUID 同步路径为 `FeedPollingService` wrapper。
+- `[ ]` 删除 legacy config 全局读取点，`get_config_manager()` 只保留在 infrastructure config Adapter 和过渡层。
+- `[ ]` 减少 `src/infrastructure/__init__.py`、`src/application/services/__init__.py` 的 eager exports。
+- `[ ]` 根据真实调用情况清理旧兼容别名和未使用 DTO。
 
 ## `docs/llm` 删除建议
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 | `/sub_import [文件路径]`                   | `/导入订阅` | 从 TOML 文件导入订阅；也可直接上传 TOML 文件进行导入 |
 | `/activate_subs`                       | `/enable_subs`, `/启用全部订阅` | 启用当前会话所有订阅 |
 | `/deactivate_subs`                     | `/disable_subs`, `/禁用全部订阅` | 禁用当前会话所有订阅 |
+| `/rss_stop`                            | `/停止RSS`, `/停止推送` | 停止当前会话正在运行的 RSS 推送任务；同一会话的推送任务会自动排队串行执行 |
 
 **布尔值格式支持**：所有命令中的布尔值参数支持以下格式：`true`/`false`, `yes`/`no`, `y`/`n`, `1`/`0`, `on`/`off`, `enable`/`disable`
 

--- a/main.py
+++ b/main.py
@@ -30,7 +30,12 @@ from .src.application.queries import (
     GetSubscriptionsQuery,
     SearchFeedsQuery,
 )
-from .src.application.services import FeedSyncService
+from .src.application.services import (
+    FeedPollingService,
+    FeedSyncService,
+    NotificationDispatcher,
+)
+from .src.application.services.session_push_queue import SessionPushQueue
 from .src.application.settings import ApplicationSettings
 from .src.domain.repositories.subscription_repository import SubscriptionRepository
 from .src.infrastructure.config import (
@@ -42,7 +47,6 @@ from .src.infrastructure.fetcher.rss import RSSFeedFetcher
 from .src.infrastructure.fetcher.rss.parser import RSSParser
 from .src.infrastructure.messaging import (
     InfrastructureMessageSenderProvider,
-    get_notification_service,
 )
 from .src.infrastructure.persistence import (
     get_database,
@@ -78,6 +82,7 @@ class _Deps(TypedDict):
     get_items_query: GetFeedItemsQuery
     search_feeds_query: SearchFeedsQuery
     sync_service: FeedSyncService
+    polling_service: FeedPollingService
     subscription_repo: SubscriptionRepository
 
 
@@ -93,6 +98,8 @@ class Main(Star):
         self._deps: _Deps = {}
         self._app_settings = ApplicationSettings()
         self._sender_provider = InfrastructureMessageSenderProvider()
+        self._push_job_queue = SessionPushQueue()
+        self._notification_dispatcher: NotificationDispatcher | None = None
 
     async def initialize(self):
         try:
@@ -110,6 +117,7 @@ class Main(Star):
         logger.info("正在停止 RSSHub 插件...")
         if self._scheduler:
             await self._scheduler.stop()
+        await self._push_job_queue.stop_all()
         db = get_database()
         if db:
             await db.close()
@@ -145,6 +153,24 @@ class Main(Star):
         feed_repo = get_feed_repository()
         sub_repo = get_subscription_repository()
         user_repo = get_user_repository()
+        push_history_repo = get_push_history_repository()
+        notification_dispatcher = NotificationDispatcher(
+            subscription_repo=sub_repo,
+            push_history_repo=push_history_repo,
+            sender_provider=self._sender_provider,
+            push_job_queue=self._push_job_queue,
+        )
+        self._notification_dispatcher = notification_dispatcher
+        polling_service = FeedPollingService(
+            feed_repo=feed_repo,
+            subscription_repo=sub_repo,
+            fetch_settings=self._app_settings.fetch,
+            rss_settings=self._app_settings.rss,
+            fetcher_factory=RSSFeedFetcher,
+            parser=RSSParser(),
+            notification_dispatcher=notification_dispatcher,
+            history_entry_limit=self._app_settings.scheduler.history_entry_limit,
+        )
 
         self._deps = _Deps(
             subscribe_cmd=SubscribeFeedCommand(
@@ -159,8 +185,10 @@ class Main(Star):
             sub_state_cmd=SubStateCommand(subscription_repo=sub_repo),
             refresh_cmd=RefreshFeedCommand(
                 feed_repo=feed_repo,
+                subscription_repo=sub_repo,
                 fetch_settings=self._app_settings.fetch,
                 fetcher_factory=RSSFeedFetcher,
+                polling_service=polling_service,
             ),
             update_sub_cmd=UpdateSubscriptionCommand(subscription_repo=sub_repo),
             list_query=GetFeedListQuery(
@@ -180,8 +208,7 @@ class Main(Star):
             test_sub_cmd=TestSubscriptionCommand(
                 subscription_repo=sub_repo,
                 feed_repo=feed_repo,
-                fetcher=RSSFeedFetcher(),
-                parser=RSSParser(),
+                polling_service=polling_service,
             ),
             get_subs_query=GetSubscriptionsQuery(subscription_repo=sub_repo),
             get_items_query=GetFeedItemsQuery(feed_repo=feed_repo),
@@ -190,32 +217,21 @@ class Main(Star):
                 feed_repo=feed_repo,
                 subscription_repo=sub_repo,
                 fetch_settings=self._app_settings.fetch,
+                rss_settings=self._app_settings.rss,
                 fetcher_factory=RSSFeedFetcher,
                 parser=RSSParser(),
+                polling_service=polling_service,
             ),
+            polling_service=polling_service,
             subscription_repo=sub_repo,
         )
 
     async def _init_scheduler(self):
-        config = get_config_manager()
-        sub_repo = get_subscription_repository()
-        push_history_repo = get_push_history_repository()
-
-        notification_svc = get_notification_service(
-            subscription_repo=sub_repo,
-            push_history_repo=push_history_repo,
-            sender_provider=self._sender_provider,
-        )
-
-        basic = config.basic_config if config else None
         self._scheduler = RSSScheduler(
-            notification_service=notification_svc,
-            hash_history_min=getattr(basic, "hash_history_min", 200),
-            hash_history_multiplier=getattr(basic, "hash_history_multiplier", 2),
-            hash_history_hard_limit=getattr(basic, "hash_history_hard_limit", 5000),
-            bootstrap_skip_history=getattr(basic, "bootstrap_skip_history", True),
-            history_entry_limit=getattr(basic, "history_entry_limit", 0),
-            sender_provider=self._sender_provider,
+            feed_polling_service=self._deps["polling_service"],
+            notification_dispatcher=self._notification_dispatcher,
+            default_interval=self._app_settings.scheduler.default_interval,
+            history_retention_days=self._app_settings.scheduler.history_retention_days,
         )
 
         await self._scheduler.start()
@@ -283,6 +299,12 @@ class Main(Star):
     @filter.command("refresh")
     async def refresh_feed(self, event: AstrMessageEvent, feed_id: int = 0):
         result = await _h.handle_refresh(event, feed_id, self._deps)
+        if result.get("plain"):
+            yield event.plain_result(result["plain"])
+
+    @filter.command("rss_stop", alias={"停止RSS", "停止推送"})
+    async def stop_rss_job(self, event: AstrMessageEvent):
+        result = _h.handle_rss_stop(event, self._push_job_queue)
         if result.get("plain"):
             yield event.plain_result(result["plain"])
 

--- a/src/application/__init__.py
+++ b/src/application/__init__.py
@@ -17,7 +17,12 @@ from .queries import (
     SearchFeedsResult,
     SubscriptionsResult,
 )
-from .services import FeedSyncService, NotificationDispatcher
+from .services import (
+    FeedPollingResult,
+    FeedPollingService,
+    FeedSyncService,
+    NotificationDispatcher,
+)
 
 __all__ = [
     # Commands
@@ -41,6 +46,8 @@ __all__ = [
     "ItemDTO",
     "SubscriptionDTO",
     # Services
+    "FeedPollingResult",
+    "FeedPollingService",
     "FeedSyncService",
     "NotificationDispatcher",
 ]

--- a/src/application/commands/refresh_feed_cmd.py
+++ b/src/application/commands/refresh_feed_cmd.py
@@ -9,6 +9,7 @@ from ...domain.repositories.subscription_repository import SubscriptionRepositor
 from ..dto.feed_dto import FeedDTO
 from ..dto.result_dto import CommandResult
 from ..ports import FeedFetcherFactory
+from ..services.feed_polling_service import FeedPollingService
 from ..settings import FeedFetchSettings
 
 
@@ -25,11 +26,13 @@ class RefreshFeedCommand:
         subscription_repo: SubscriptionRepository | None = None,
         fetch_settings: FeedFetchSettings | None = None,
         fetcher_factory: FeedFetcherFactory | None = None,
+        polling_service: FeedPollingService | None = None,
     ):
         self._feed_repo = feed_repo
         self._subscription_repo = subscription_repo
         self._fetch_settings = fetch_settings or FeedFetchSettings()
         self._fetcher_factory = fetcher_factory
+        self._polling_service = polling_service
 
     async def execute(self, feed_id: int) -> CommandResult:
         """
@@ -41,6 +44,36 @@ class RefreshFeedCommand:
         Returns:
             CommandResult: 命令执行结果
         """
+        if self._polling_service is not None:
+            polling_result = await self._polling_service.poll_feed(feed_id)
+            if not polling_result.success:
+                return CommandResult(
+                    success=False,
+                    message=polling_result.message,
+                    data=polling_result,
+                )
+            if polling_result.feed is None:
+                return CommandResult(
+                    success=True,
+                    message=polling_result.message,
+                    data=polling_result,
+                )
+            feed = polling_result.feed
+            return CommandResult(
+                success=True,
+                message=polling_result.message,
+                data=FeedDTO(
+                    id=feed.id,
+                    link=feed.link,
+                    title=feed.title,
+                    state=feed.state,
+                    etag=feed.etag,
+                    last_modified=feed.last_modified,
+                    created_at=feed.created_at,
+                    updated_at=feed.updated_at,
+                ),
+            )
+
         feed = await self._feed_repo.get_by_id(feed_id)
         if not feed:
             return CommandResult(

--- a/src/application/commands/test_subscription_cmd.py
+++ b/src/application/commands/test_subscription_cmd.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from ...domain.repositories.feed_repository import FeedRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
@@ -13,6 +14,7 @@ from ..dto.feed_dto import FeedDTO
 from ..dto.result_dto import CommandResult
 from ..dto.subscription_dto import SubscriptionDTO
 from ..ports import FeedFetcher, FeedParser
+from ..services.feed_polling_service import FeedPollingService, FeedReadResult
 
 
 @dataclass
@@ -35,13 +37,15 @@ class TestSubscriptionCommand:
         self,
         subscription_repo: SubscriptionRepository,
         feed_repo: FeedRepository,
-        fetcher: FeedFetcher,
-        parser: FeedParser,
+        fetcher: FeedFetcher | None = None,
+        parser: FeedParser | None = None,
+        polling_service: FeedPollingService | None = None,
     ):
         self._subscription_repo = subscription_repo
         self._feed_repo = feed_repo
         self._fetcher = fetcher
         self._parser = parser
+        self._polling_service = polling_service
 
     async def execute(
         self,
@@ -81,36 +85,13 @@ class TestSubscriptionCommand:
                 message=f"Feed 不存在 (ID: {subscription.feed_id})",
             )
 
-        # 3. 抓取 Feed
-        try:
-            web_feed = await self._fetcher.fetch(feed.link)
-        except Exception as e:
-            return CommandResult(
-                success=False,
-                message=f"抓取失败: {e}",
-            )
+        # 3. 抓取并解析 Feed
+        read_result = await self._fetch_entries(feed.link)
+        if not read_result.success:
+            return CommandResult(success=False, message=read_result.message)
 
-        if web_feed.error:
-            return CommandResult(
-                success=False,
-                message=f"抓取失败: {web_feed.error}",
-            )
-
-        # 4. 解析 Feed
-        try:
-            entries, parse_error = self._parser.parse(web_feed.content)
-        except Exception as e:
-            return CommandResult(
-                success=False,
-                message=f"解析失败: {e}",
-            )
-
-        if parse_error:
-            return CommandResult(
-                success=False,
-                message=f"解析失败: {parse_error}",
-            )
-
+        web_feed = read_result.web_feed
+        entries = read_result.entries
         if not entries:
             return CommandResult(
                 success=False,
@@ -118,11 +99,15 @@ class TestSubscriptionCommand:
             )
 
         # 5. 构建结果
+        feed_meta = self._feed_meta(web_feed)
         feed_dto = FeedDTO(
             id=feed.id,
             link=feed.link,
-            title=feed.title or web_feed.rss_d.feed.get("title", "未知"),
-            description=feed.description or web_feed.rss_d.feed.get("description", ""),
+            title=feed.title or feed_meta.get("title", "未知"),
+            state=feed.state,
+            etag=feed.etag,
+            last_modified=feed.last_modified,
+            created_at=feed.created_at,
             updated_at=feed.updated_at,
         )
 
@@ -185,36 +170,13 @@ class TestSubscriptionCommand:
         Returns:
             CommandResult: 命令执行结果
         """
-        # 1. 抓取 Feed
-        try:
-            web_feed = await self._fetcher.fetch(url)
-        except Exception as e:
-            return CommandResult(
-                success=False,
-                message=f"抓取失败: {e}",
-            )
+        # 1. 抓取并解析 Feed
+        read_result = await self._fetch_entries(url)
+        if not read_result.success:
+            return CommandResult(success=False, message=read_result.message)
 
-        if web_feed.error:
-            return CommandResult(
-                success=False,
-                message=f"抓取失败: {web_feed.error}",
-            )
-
-        # 2. 解析 Feed
-        try:
-            entries, parse_error = self._parser.parse(web_feed.content)
-        except Exception as e:
-            return CommandResult(
-                success=False,
-                message=f"解析失败: {e}",
-            )
-
-        if parse_error:
-            return CommandResult(
-                success=False,
-                message=f"解析失败: {parse_error}",
-            )
-
+        web_feed = read_result.web_feed
+        entries = read_result.entries
         if not entries:
             return CommandResult(
                 success=False,
@@ -222,12 +184,14 @@ class TestSubscriptionCommand:
             )
 
         # 3. 构建结果
+        feed_meta = self._feed_meta(web_feed)
+        now = datetime.now(timezone.utc)
         feed_dto = FeedDTO(
             id=0,  # 临时 ID
             link=url,
-            title=web_feed.rss_d.feed.get("title", "未知"),
-            description=web_feed.rss_d.feed.get("description", ""),
-            updated_at=None,
+            title=feed_meta.get("title", "未知"),
+            created_at=now,
+            updated_at=now,
         )
 
         # 提取示例条目
@@ -258,3 +222,63 @@ class TestSubscriptionCommand:
             message=f"测试成功! Feed 共有 {len(entries)} 个条目",
             data={"test_result": result},
         )
+
+    async def _fetch_entries(self, url: str) -> FeedReadResult:
+        if self._polling_service is not None:
+            return await self._polling_service.fetch_feed_entries(url, verbose=True)
+
+        if self._fetcher is None or self._parser is None:
+            raise RuntimeError("TestSubscriptionCommand requires feed read ports")
+
+        try:
+            web_feed = await self._fetcher.fetch(url)
+        except Exception as e:
+            return FeedReadResult(
+                success=False,
+                status="fetch_error",
+                message=f"抓取失败: {e}",
+                error=str(e),
+            )
+
+        if web_feed.error:
+            return FeedReadResult(
+                success=False,
+                status="fetch_error",
+                message=f"抓取失败: {web_feed.error}",
+                web_feed=web_feed,
+                error=str(web_feed.error),
+            )
+
+        try:
+            entries, parse_error = self._parser.parse(web_feed.content)
+        except Exception as e:
+            return FeedReadResult(
+                success=False,
+                status="parse_error",
+                message=f"解析失败: {e}",
+                web_feed=web_feed,
+                error=str(e),
+            )
+
+        if parse_error:
+            return FeedReadResult(
+                success=False,
+                status="parse_error",
+                message=f"解析失败: {parse_error}",
+                web_feed=web_feed,
+                error=parse_error,
+            )
+
+        return FeedReadResult(
+            success=True,
+            status="fetched",
+            message=f"抓取完成，发现 {len(entries)} 个条目",
+            entries=entries,
+            web_feed=web_feed,
+        )
+
+    @staticmethod
+    def _feed_meta(web_feed) -> dict:
+        rss_d = getattr(web_feed, "rss_d", None)
+        feed_meta = getattr(rss_d, "feed", {}) if rss_d else {}
+        return feed_meta if hasattr(feed_meta, "get") else {}

--- a/src/application/ports/__init__.py
+++ b/src/application/ports/__init__.py
@@ -7,6 +7,7 @@ for these protocols at composition time.
 from .clock import Clock, SystemClock
 from .feed_fetcher import FeedFetcher, FeedFetcherFactory
 from .feed_parser import FeedParser
+from .media_fingerprint import MediaFingerprintService
 from .message_sender import (
     MessageContext,
     MessageSender,
@@ -21,6 +22,7 @@ __all__ = [
     "FeedFetcherFactory",
     "FeedParser",
     "MessageContext",
+    "MediaFingerprintService",
     "MessageSender",
     "MessageSenderProvider",
     "SendRequest",

--- a/src/application/ports/media_fingerprint.py
+++ b/src/application/ports/media_fingerprint.py
@@ -1,0 +1,13 @@
+"""Media fingerprinting port."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class MediaFingerprintService(Protocol):
+    """Calculate stable fingerprints for media URLs."""
+
+    async def fingerprint_urls(self, urls: list[str]) -> list[str]:
+        """Return media fingerprints for the given URLs."""
+        ...

--- a/src/application/queries/get_subscriptions_query.py
+++ b/src/application/queries/get_subscriptions_query.py
@@ -57,9 +57,10 @@ class GetSubscriptionsQuery:
             SubscriptionsResult: 查询结果
         """
         # 需要从 persistence 层获取订阅并加载关联的 Feed
-        from ...infrastructure.persistence.database import get_database
-        from ...infrastructure.persistence.models import SubORM, FeedORM
         from sqlmodel import select
+
+        from ...infrastructure.persistence.database import get_database
+        from ...infrastructure.persistence.models import FeedORM, SubORM
 
         db = get_database()
         async with db.get_session() as session:

--- a/src/application/services/__init__.py
+++ b/src/application/services/__init__.py
@@ -1,8 +1,15 @@
 """应用服务包"""
 
+from .feed_polling_service import FeedPollingResult, FeedPollingService, FeedReadResult
 from .feed_sync_service import FeedSyncService
 from .html_parser import HTMLCleaner, HTMLParser, clean_html, parse_html
 from .notification_dispatcher import NotificationDispatcher
+from .session_push_queue import (
+    PushJob,
+    PushJobResult,
+    SessionPushQueue,
+    StopPushJobResult,
+)
 from .subscription_serializer import (
     ImportSubscriptionRecord,
     SubscriptionImportPayload,
@@ -12,7 +19,14 @@ from .subscription_serializer import (
 
 __all__ = [
     "FeedSyncService",
+    "FeedPollingService",
+    "FeedPollingResult",
+    "FeedReadResult",
     "NotificationDispatcher",
+    "SessionPushQueue",
+    "PushJob",
+    "PushJobResult",
+    "StopPushJobResult",
     # HTML Parser
     "HTMLParser",
     "HTMLCleaner",

--- a/src/application/services/feed_polling_service.py
+++ b/src/application/services/feed_polling_service.py
@@ -19,7 +19,7 @@ from itertools import chain
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 
-from ...domain.entities.feed import Feed
+from ...domain.entities.feed import Feed, normalize_entry_hashes
 from ...domain.repositories.feed_repository import FeedRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
 from ...infrastructure.utils import get_logger
@@ -240,7 +240,7 @@ class FeedPollingService:
 
         entries = read_result.entries
         self._apply_feed_metadata(feed, web_feed)
-        old_groups = self._migrate_hashes(feed.entry_hashes or [])
+        old_groups = normalize_entry_hashes(feed.entry_hashes) or []
         new_groups, new_entries = self._calculate_update(
             old_groups,
             entries,
@@ -365,31 +365,6 @@ class FeedPollingService:
         last_modified = getattr(web_feed, "last_modified", None)
         if last_modified:
             feed.last_modified = last_modified
-
-    def _migrate_hashes(self, raw: list[Any]) -> list[list[str]]:
-        """Normalize legacy flat hash storage to grouped hash history."""
-        if not raw:
-            return []
-        if isinstance(raw[0], list):
-            return [
-                [str(value) for value in group if value]
-                for group in raw
-                if isinstance(group, list) and group
-            ]
-
-        groups: list[list[str]] = []
-        current: list[str] = []
-        for value in raw:
-            item = str(value or "")
-            if not item:
-                continue
-            if item.startswith("sid:") and current:
-                groups.append(current)
-                current = []
-            current.append(item)
-        if current:
-            groups.append(current)
-        return groups
 
     def _calculate_update(
         self,
@@ -553,6 +528,10 @@ class FeedPollingService:
         if feed_link and not link.startswith("http"):
             link = urljoin(feed_link, link)
 
+        return self._strip_tracking_params(link)
+
+    def _strip_tracking_params(self, link: str) -> str:
+        """Remove configured tracking parameters from an entry URL."""
         try:
             parsed = urlparse(link)
             if parsed.query:
@@ -619,11 +598,7 @@ class FeedPollingService:
 
         for entry in sorted_entries:
             title = str(self._entry_value(entry, "title") or "")
-            link = str(
-                self._entry_value(entry, "link")
-                or self._entry_value(entry, "guid")
-                or ""
-            )
+            link = self._resolve_entry_link(entry, feed.link)
             guid = self._entry_identity(entry)
             content = str(
                 self._entry_value(entry, "content")

--- a/src/application/services/feed_polling_service.py
+++ b/src/application/services/feed_polling_service.py
@@ -640,8 +640,10 @@ class FeedPollingService:
             ]
             if self._media_fingerprint_service is not None and media_urls:
                 try:
-                    media_hashes = await self._media_fingerprint_service.fingerprint_urls(
-                        media_urls
+                    media_hashes = (
+                        await self._media_fingerprint_service.fingerprint_urls(
+                            media_urls
+                        )
                     )
                     if media_hashes:
                         logger.debug(

--- a/src/application/services/feed_polling_service.py
+++ b/src/application/services/feed_polling_service.py
@@ -1,0 +1,683 @@
+"""Unified feed polling use case.
+
+This service owns the application-level polling workflow:
+load feed, fetch RSS, parse entries, update dedup state, and optionally dispatch
+new entries. Scheduler adapters and manual refresh commands should converge on
+this service instead of duplicating sync behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import re
+import zlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from itertools import chain
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
+
+from ...domain.entities.feed import Feed
+from ...domain.repositories.feed_repository import FeedRepository
+from ...domain.repositories.subscription_repository import SubscriptionRepository
+from ...infrastructure.utils import get_logger
+from ..ports import FeedFetcherFactory, FeedParser, MediaFingerprintService
+from ..settings import FeedFetchSettings, RSSSettings
+from .notification_dispatcher import NotificationDispatcher
+
+logger = get_logger()
+
+DEFAULT_TRACKING_QUERY_PARAMS = frozenset(
+    {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "utm_id",
+        "gclid",
+        "fbclid",
+        "mc_cid",
+        "mc_eid",
+        "spm",
+        "ref",
+        "ref_src",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FeedReadResult:
+    """Result of fetching and parsing one feed URL."""
+
+    success: bool
+    status: str
+    message: str
+    entries: list[Any] = field(default_factory=list)
+    web_feed: Any | None = None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class FeedPollingResult:
+    """Result of one feed polling run."""
+
+    success: bool
+    status: str
+    message: str
+    feed_id: int | None = None
+    total_entries: int = 0
+    new_entries: int = 0
+    dispatched: int = 0
+    bootstrap_skipped: bool = False
+    feed: Feed | None = None
+    error: str = ""
+
+
+class FeedPollingService:
+    """Unified application service for polling RSS feeds."""
+
+    def __init__(
+        self,
+        feed_repo: FeedRepository,
+        subscription_repo: SubscriptionRepository,
+        fetch_settings: FeedFetchSettings | None = None,
+        rss_settings: RSSSettings | None = None,
+        fetcher_factory: FeedFetcherFactory | None = None,
+        parser: FeedParser | None = None,
+        notification_dispatcher: NotificationDispatcher | None = None,
+        media_fingerprint_service: MediaFingerprintService | None = None,
+        history_entry_limit: int = 0,
+    ) -> None:
+        self._feed_repo = feed_repo
+        self._subscription_repo = subscription_repo
+        self._fetch_settings = fetch_settings or FeedFetchSettings()
+        self._rss_settings = rss_settings or RSSSettings()
+        self._fetcher_factory = fetcher_factory
+        self._parser = parser
+        self._notification_dispatcher = notification_dispatcher
+        self._media_fingerprint_service = media_fingerprint_service
+        self._history_entry_limit = max(0, history_entry_limit)
+
+    async def fetch_feed_entries(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        verbose: bool = False,
+    ) -> FeedReadResult:
+        """Fetch and parse one feed URL without mutating feed state."""
+        if self._fetcher_factory is None or self._parser is None:
+            raise RuntimeError(
+                "FeedPollingService requires feed fetcher and parser ports"
+            )
+
+        fetcher = self._fetcher_factory(
+            timeout=self._fetch_settings.timeout,
+            proxy=self._fetch_settings.proxy,
+        )
+
+        try:
+            web_feed = await fetcher.fetch(
+                url,
+                headers=headers,
+                verbose=verbose,
+            )
+        except Exception as ex:
+            logger.warning("fetch_feed_entries: 抓取异常: feed=%s, err=%s", url, ex)
+            return FeedReadResult(
+                success=False,
+                status="fetch_error",
+                message=f"抓取失败: {ex}",
+                error=str(ex),
+            )
+        finally:
+            await fetcher.close()
+
+        if getattr(web_feed, "status", 0) == 304:
+            return FeedReadResult(
+                success=True,
+                status="not_modified",
+                message="Feed 未修改，无需更新",
+                web_feed=web_feed,
+            )
+
+        if web_feed.error:
+            error_name = getattr(web_feed.error, "error_name", str(web_feed.error))
+            logger.warning(
+                "fetch_feed_entries: 抓取失败: feed=%s, err=%s",
+                url,
+                error_name,
+            )
+            return FeedReadResult(
+                success=False,
+                status="fetch_error",
+                message=f"抓取失败: {error_name}",
+                web_feed=web_feed,
+                error=error_name,
+            )
+
+        if not web_feed.content:
+            return FeedReadResult(
+                success=False,
+                status="empty_content",
+                message="抓取失败: RSS 内容为空",
+                web_feed=web_feed,
+                error="empty_content",
+            )
+
+        entries, parse_err = self._parser.parse(web_feed.content)
+        if parse_err:
+            logger.warning(
+                "fetch_feed_entries: 解析失败: feed=%s, err=%s",
+                url,
+                parse_err,
+            )
+            return FeedReadResult(
+                success=False,
+                status="parse_error",
+                message=f"解析失败: {parse_err}",
+                web_feed=web_feed,
+                error=parse_err,
+            )
+
+        return FeedReadResult(
+            success=True,
+            status="fetched",
+            message=f"抓取完成，发现 {len(entries)} 个条目",
+            entries=entries,
+            web_feed=web_feed,
+        )
+
+    async def poll_feed(
+        self,
+        feed_id: int,
+        *,
+        notify_new_entries: bool = False,
+        subscription_ids: list[int] | None = None,
+        verbose: bool = False,
+    ) -> FeedPollingResult:
+        """Poll one feed and update its dedup history."""
+        feed = await self._feed_repo.get_by_id(feed_id)
+        if not feed:
+            logger.warning("poll_feed: Feed %s 不存在", feed_id)
+            return FeedPollingResult(
+                success=False,
+                status="not_found",
+                message=f"Feed 不存在 (ID: {feed_id})",
+                feed_id=feed_id,
+                error="feed_not_found",
+            )
+
+        headers = self._build_conditional_headers(feed)
+        read_result = await self.fetch_feed_entries(
+            feed.link,
+            headers=headers,
+            verbose=verbose,
+        )
+        web_feed = read_result.web_feed
+
+        if read_result.status == "not_modified":
+            return FeedPollingResult(
+                success=True,
+                status="not_modified",
+                message=f"Feed 未修改，无需更新 (ID: {feed_id})",
+                feed_id=feed.id,
+                feed=feed,
+            )
+
+        if not read_result.success:
+            return FeedPollingResult(
+                success=False,
+                status=read_result.status,
+                message=read_result.message,
+                feed_id=feed.id,
+                feed=feed,
+                error=read_result.error,
+            )
+
+        entries = read_result.entries
+        self._apply_feed_metadata(feed, web_feed)
+        old_groups = self._migrate_hashes(feed.entry_hashes or [])
+        new_groups, new_entries = self._calculate_update(
+            old_groups,
+            entries,
+            feed_link=feed.link,
+        )
+        feed.entry_hashes = self._merge_hash_history(
+            old_groups,
+            new_groups,
+            len(entries),
+        )
+        feed.updated_at = datetime.now(timezone.utc)
+        saved_feed = await self._feed_repo.save(feed)
+
+        dispatched = 0
+        bootstrap_skipped = bool(
+            notify_new_entries
+            and new_entries
+            and not old_groups
+            and self._rss_settings.bootstrap_skip_history
+        )
+        if (
+            notify_new_entries
+            and new_entries
+            and not bootstrap_skipped
+            and self._notification_dispatcher
+        ):
+            dispatched = await self._dispatch_entries(
+                saved_feed,
+                new_entries,
+                subscription_ids=subscription_ids,
+            )
+
+        message = f"刷新完成 (ID: {feed_id})，发现 {len(entries)} 个条目"
+        if bootstrap_skipped:
+            message += f"，首次初始化跳过历史 {len(new_entries)} 个"
+        elif new_entries:
+            message += f"，新增 {len(new_entries)} 个"
+        else:
+            message += "，无新增"
+
+        logger.info(
+            "poll_feed: feed=%s, total=%d, new=%d, dispatched=%d",
+            feed.link,
+            len(entries),
+            len(new_entries),
+            dispatched,
+        )
+        return FeedPollingResult(
+            success=True,
+            status=(
+                "bootstrapped"
+                if bootstrap_skipped
+                else "updated"
+                if new_entries
+                else "no_new_entries"
+            ),
+            message=message,
+            feed_id=saved_feed.id,
+            total_entries=len(entries),
+            new_entries=len(new_entries),
+            dispatched=dispatched,
+            bootstrap_skipped=bootstrap_skipped,
+            feed=saved_feed,
+        )
+
+    async def poll_feed_group(
+        self,
+        feed_id: int,
+        subscription_ids: list[int],
+        *,
+        notify_new_entries: bool = True,
+        verbose: bool = False,
+    ) -> FeedPollingResult:
+        """Poll one feed and dispatch only to the selected subscriptions."""
+        return await self.poll_feed(
+            feed_id,
+            notify_new_entries=notify_new_entries,
+            subscription_ids=list(dict.fromkeys(subscription_ids)),
+            verbose=verbose,
+        )
+
+    async def poll_all_active_feeds(
+        self,
+        *,
+        notify_new_entries: bool = False,
+    ) -> list[FeedPollingResult]:
+        """Poll all active feeds."""
+        feeds = await self._feed_repo.get_all_active()
+        results: list[FeedPollingResult] = []
+        for feed in feeds:
+            if feed.id is None:
+                continue
+            results.append(
+                await self.poll_feed(
+                    feed.id,
+                    notify_new_entries=notify_new_entries,
+                )
+            )
+        return results
+
+    @staticmethod
+    def _build_conditional_headers(feed: Feed) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if feed.etag:
+            headers["If-None-Match"] = feed.etag
+        if feed.last_modified:
+            headers["If-Modified-Since"] = format_datetime(feed.last_modified)
+        return headers
+
+    @staticmethod
+    def _apply_feed_metadata(feed: Feed, web_feed: Any) -> None:
+        rss_d = getattr(web_feed, "rss_d", None)
+        feed_meta = getattr(rss_d, "feed", {}) if rss_d else {}
+        title = feed_meta.get("title", "") if hasattr(feed_meta, "get") else ""
+        if title:
+            feed.title = str(title)[:1024]
+
+        etag = getattr(web_feed, "etag", None)
+        if etag:
+            feed.etag = etag
+
+        last_modified = getattr(web_feed, "last_modified", None)
+        if last_modified:
+            feed.last_modified = last_modified
+
+    def _migrate_hashes(self, raw: list[Any]) -> list[list[str]]:
+        """Normalize legacy flat hash storage to grouped hash history."""
+        if not raw:
+            return []
+        if isinstance(raw[0], list):
+            return [
+                [str(value) for value in group if value]
+                for group in raw
+                if isinstance(group, list) and group
+            ]
+
+        groups: list[list[str]] = []
+        current: list[str] = []
+        for value in raw:
+            item = str(value or "")
+            if not item:
+                continue
+            if item.startswith("sid:") and current:
+                groups.append(current)
+                current = []
+            current.append(item)
+        if current:
+            groups.append(current)
+        return groups
+
+    def _calculate_update(
+        self,
+        old_groups: list[list[str]],
+        entries: list[Any],
+        feed_link: str | None = None,
+    ) -> tuple[list[list[str]], list[Any]]:
+        """Calculate new grouped fingerprints and entries not seen before."""
+        known_hashes = {value for group in old_groups for value in group if value}
+        new_groups: list[list[str]] = []
+        new_entries: list[Any] = []
+
+        for entry in entries:
+            entry_hashes = self._hash_entry(entry, feed_link)
+            stable_hash = next((h for h in entry_hashes if h.startswith("sid:")), "")
+            known_by_identity = bool(stable_hash) and stable_hash in known_hashes
+            known_by_any_hash = any(h in known_hashes for h in entry_hashes)
+
+            if not (known_by_identity or known_by_any_hash):
+                new_entries.append(entry)
+
+            new_groups.append(entry_hashes)
+            known_hashes.update(entry_hashes)
+
+        return new_groups, new_entries
+
+    def _hash_entry(self, entry: Any, feed_link: str | None = None) -> list[str]:
+        """Build stable and compatibility fingerprints for one entry."""
+        upstream_material = self._upstream_material(entry)
+        upstream_crc = (
+            hex(zlib.crc32(upstream_material.encode("utf-8", errors="ignore")))[2:]
+            if upstream_material
+            else ""
+        )
+
+        entry_id = self._normalize_identifier(
+            str(
+                self._entry_value(entry, "id")
+                or self._entry_value(entry, "entry_id")
+                or self._entry_value(entry, "guid")
+                or ""
+            )
+        )
+        link = self._resolve_entry_link(entry, feed_link)
+        title = self._normalize_text(str(self._entry_value(entry, "title") or ""))
+        summary = self._normalize_text(
+            str(
+                self._entry_value(entry, "summary")
+                or self._entry_value(entry, "description")
+                or self._entry_value(entry, "content")
+                or ""
+            ),
+            max_length=2048,
+        )
+
+        stable_material = ""
+        if entry_id:
+            stable_material = f"v3|id={entry_id}"
+        elif link:
+            stable_material = f"v3|link={link}"
+        elif title:
+            stable_material = f"v3|title={title}"
+        elif summary:
+            stable_material = f"v3|summary={summary[:256]}"
+
+        content_material = f"v3|title={title}|link={link}|summary={summary[:512]}"
+
+        fingerprints: list[str] = []
+        if stable_material:
+            fingerprints.append(
+                f"sid:{hashlib.sha256(stable_material.encode()).hexdigest()}"
+            )
+
+        content_hash = hashlib.sha256(content_material.encode()).hexdigest()
+        fingerprints.append(content_hash)
+
+        for compat_hash in (
+            upstream_crc,
+            self._legacy_crc32(entry),
+            self._entry_identity(entry),
+        ):
+            if compat_hash and compat_hash not in fingerprints:
+                fingerprints.append(compat_hash)
+
+        return fingerprints
+
+    def _merge_hash_history(
+        self,
+        old_groups: list[list[str]],
+        new_groups: list[list[str]],
+        entry_count: int,
+    ) -> list[list[str]] | None:
+        """Merge newest fingerprints with previous history under a bounded size."""
+        history_limit = self._resolve_hash_history_limit(entry_count)
+        merged: list[list[str]] = []
+        seen_identity: set[str] = set()
+
+        for group in chain(new_groups, old_groups):
+            if not group:
+                continue
+            identity = next((h for h in group if h.startswith("sid:")), None)
+            if identity and identity in seen_identity:
+                continue
+            if identity:
+                seen_identity.add(identity)
+            merged.append(group)
+            if len(merged) >= history_limit:
+                break
+
+        return merged or None
+
+    def _resolve_hash_history_limit(self, entry_count: int) -> int:
+        min_limit = min(max(1, self._rss_settings.hash_history_min), 20000)
+        multiplier = min(max(1, self._rss_settings.hash_history_multiplier), 20000)
+        hard_limit = min(
+            max(min_limit, self._rss_settings.hash_history_hard_limit), 20000
+        )
+        growth_limit = max(entry_count, 1) * multiplier
+        return min(max(min_limit, growth_limit), hard_limit)
+
+    @staticmethod
+    def _entry_value(entry: Any, key: str, default: Any = "") -> Any:
+        if isinstance(entry, dict):
+            return entry.get(key, default)
+        return getattr(entry, key, default)
+
+    def _entry_identity(self, entry: Any) -> str:
+        for key in ("guid", "entry_id", "id", "link"):
+            value = self._entry_value(entry, key)
+            if value:
+                return str(value)
+        return ""
+
+    def _upstream_material(self, entry: Any) -> str:
+        content = self._entry_value(entry, "content") or ""
+        first_content_value = ""
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("value"):
+                    first_content_value = str(item["value"]).strip()
+                    break
+        elif content:
+            first_content_value = str(content).strip()
+
+        return "\n".join(
+            [
+                str(self._entry_value(entry, "guid") or "").strip(),
+                str(self._entry_value(entry, "link") or "").strip(),
+                str(self._entry_value(entry, "title") or "").strip(),
+                str(self._entry_value(entry, "summary") or "").strip(),
+                first_content_value,
+            ]
+        )
+
+    def _resolve_entry_link(self, entry: Any, feed_link: str | None = None) -> str:
+        link = str(
+            self._entry_value(entry, "link") or self._entry_value(entry, "guid") or ""
+        ).strip()
+        if not link:
+            return ""
+        if feed_link and not link.startswith("http"):
+            link = urljoin(feed_link, link)
+
+        try:
+            parsed = urlparse(link)
+            if parsed.query:
+                tracking_params = set(
+                    self._rss_settings.tracking_query_params
+                    or DEFAULT_TRACKING_QUERY_PARAMS
+                )
+                filtered_params = [
+                    (key, value)
+                    for key, value in parse_qsl(parsed.query)
+                    if key not in tracking_params
+                ]
+                link = urlunparse(
+                    (
+                        parsed.scheme,
+                        parsed.netloc,
+                        parsed.path,
+                        parsed.params,
+                        urlencode(filtered_params),
+                        parsed.fragment,
+                    )
+                )
+        except Exception:
+            pass
+
+        return link
+
+    def _legacy_crc32(self, entry: Any) -> str:
+        hash_base = (
+            str(self._entry_value(entry, "link") or "")
+            + str(self._entry_value(entry, "title") or "")
+            + str(
+                self._entry_value(entry, "published")
+                or self._entry_value(entry, "pubDate")
+                or ""
+            )
+        )
+        return str(zlib.crc32(hash_base.encode()))
+
+    @staticmethod
+    def _normalize_text(value: str, max_length: int = 1024) -> str:
+        text = html.unescape(value or "")
+        text = re.sub(r"\s+", " ", text).strip().lower()
+        return text[:max_length]
+
+    @staticmethod
+    def _normalize_identifier(value: str, max_length: int = 1024) -> str:
+        return (value or "").strip()[:max_length]
+
+    async def _dispatch_entries(
+        self,
+        feed: Feed,
+        entries: list[Any],
+        *,
+        subscription_ids: list[int] | None = None,
+    ) -> int:
+        if self._notification_dispatcher is None or feed.id is None:
+            return 0
+
+        dispatched = 0
+        sorted_entries = sorted(entries, key=self._entry_sort_key, reverse=True)
+        if self._history_entry_limit > 0:
+            sorted_entries = sorted_entries[: self._history_entry_limit]
+
+        for entry in sorted_entries:
+            title = str(self._entry_value(entry, "title") or "")
+            link = str(
+                self._entry_value(entry, "link")
+                or self._entry_value(entry, "guid")
+                or ""
+            )
+            guid = self._entry_identity(entry)
+            content = str(
+                self._entry_value(entry, "content")
+                or self._entry_value(entry, "summary")
+                or title
+            )
+            if title and content != title:
+                content = f"{title}\n\n{content}"
+
+            media_urls = [
+                str(self._entry_value(enclosure, "url"))
+                for enclosure in (self._entry_value(entry, "enclosures", []) or [])
+                if self._entry_value(enclosure, "url")
+            ]
+            if self._media_fingerprint_service is not None and media_urls:
+                try:
+                    media_hashes = await self._media_fingerprint_service.fingerprint_urls(
+                        media_urls
+                    )
+                    if media_hashes:
+                        logger.debug(
+                            "poll_feed: media fingerprints calculated for feed=%s, count=%s",
+                            feed.id,
+                            len(media_hashes),
+                        )
+                except Exception as ex:
+                    logger.debug(
+                        "poll_feed: media fingerprint skipped: feed=%s, err=%s",
+                        feed.id,
+                        ex,
+                    )
+            stats = await self._notification_dispatcher.dispatch_to_feed_subscribers(
+                feed_id=feed.id,
+                content=content,
+                entry_title=title,
+                entry_link=link,
+                feed_title=feed.title,
+                feed_link=feed.link,
+                media_urls=media_urls,
+                entry_guid=guid,
+                subscription_ids=subscription_ids,
+            )
+            dispatched += (
+                stats.get("success", 0)
+                + stats.get("failed", 0)
+                + stats.get("pending", 0)
+            )
+        return dispatched
+
+    def _entry_sort_key(self, entry: Any) -> Any:
+        return (
+            self._entry_value(entry, "published")
+            or self._entry_value(entry, "updated")
+            or self._entry_value(entry, "published_parsed")
+            or self._entry_value(entry, "updated_parsed")
+            or ()
+        )

--- a/src/application/services/feed_sync_service.py
+++ b/src/application/services/feed_sync_service.py
@@ -7,11 +7,9 @@ Feed 同步协调服务
 
 from ...domain.repositories.feed_repository import FeedRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
-from ...infrastructure.utils import get_logger
 from ..ports import FeedFetcherFactory, FeedParser
-from ..settings import FeedFetchSettings
-
-logger = get_logger()
+from ..settings import FeedFetchSettings, RSSSettings
+from .feed_polling_service import FeedPollingResult, FeedPollingService
 
 
 class FeedSyncService:
@@ -26,16 +24,21 @@ class FeedSyncService:
         feed_repo: FeedRepository,
         subscription_repo: SubscriptionRepository,
         fetch_settings: FeedFetchSettings | None = None,
+        rss_settings: RSSSettings | None = None,
         fetcher_factory: FeedFetcherFactory | None = None,
         parser: FeedParser | None = None,
+        polling_service: FeedPollingService | None = None,
     ):
-        self._feed_repo = feed_repo
-        self._subscription_repo = subscription_repo
-        self._fetch_settings = fetch_settings or FeedFetchSettings()
-        self._fetcher_factory = fetcher_factory
-        self._parser = parser
+        self._polling_service = polling_service or FeedPollingService(
+            feed_repo=feed_repo,
+            subscription_repo=subscription_repo,
+            fetch_settings=fetch_settings,
+            rss_settings=rss_settings,
+            fetcher_factory=fetcher_factory,
+            parser=parser,
+        )
 
-    async def sync_feed(self, feed_id: int) -> None:
+    async def sync_feed(self, feed_id: int) -> FeedPollingResult:
         """
         同步单个 Feed
 
@@ -44,63 +47,8 @@ class FeedSyncService:
         Args:
             feed_id: Feed ID
         """
-        feed = await self._feed_repo.get_by_id(feed_id)
-        if not feed:
-            logger.warning("sync_feed: Feed %s 不存在", feed_id)
-            return
+        return await self._polling_service.poll_feed(feed_id)
 
-        if self._fetcher_factory is None or self._parser is None:
-            raise RuntimeError("FeedSyncService requires feed fetcher and parser ports")
-
-        fetcher = self._fetcher_factory(
-            timeout=self._fetch_settings.timeout,
-            proxy=self._fetch_settings.proxy,
-        )
-        try:
-            web_feed = await fetcher.fetch(feed.link)
-            if web_feed.error or not web_feed.content:
-                logger.warning(
-                    "sync_feed: 抓取失败: feed=%s, err=%s",
-                    feed.link,
-                    web_feed.error,
-                )
-                return
-
-            entries, parse_err = self._parser.parse(web_feed.content)
-            if parse_err:
-                logger.warning(
-                    "sync_feed: 解析失败: feed=%s, err=%s",
-                    feed.link,
-                    parse_err,
-                )
-                return
-
-            logger.info("sync_feed: feed=%s, entries=%d", feed.link, len(entries))
-
-            # 去重 + 记录新条目哈希
-            from ...domain.services.content_filter import ContentFilterService
-
-            filter_svc = ContentFilterService()
-            new_entries = []
-            for entry in entries:
-                entry_guid = entry.guid or entry.link
-                if entry_guid and not filter_svc.is_duplicate(feed, entry_guid):
-                    new_entries.append(entry)
-                    filter_svc.record_entry(feed, entry_guid)
-
-            await self._feed_repo.save(feed)
-            logger.info(
-                "sync_feed: feed=%s, total=%d, new=%d",
-                feed.link,
-                len(entries),
-                len(new_entries),
-            )
-        finally:
-            await fetcher.close()
-
-    async def sync_all_active_feeds(self) -> None:
+    async def sync_all_active_feeds(self) -> list[FeedPollingResult]:
         """同步所有启用的 Feed"""
-        feeds = await self._feed_repo.get_all_active()
-        for feed in feeds:
-            if feed.id:
-                await self.sync_feed(feed.id)
+        return await self._polling_service.poll_all_active_feeds()

--- a/src/application/services/notification_dispatcher.py
+++ b/src/application/services/notification_dispatcher.py
@@ -7,11 +7,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ...domain.entities.push_history import PushHistory
 from ...domain.repositories.push_history_repository import PushHistoryRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
 from ...infrastructure.utils import get_logger
 from ..ports import MessageContext, MessageSenderProvider, SendRequest
+from .session_push_queue import PushJob, SessionPushQueue
 
 logger = get_logger()
 
@@ -51,10 +54,12 @@ class NotificationDispatcher:
         subscription_repo: SubscriptionRepository,
         push_history_repo: PushHistoryRepository,
         sender_provider: MessageSenderProvider,
+        push_job_queue: SessionPushQueue | None = None,
     ):
         self._subscription_repo = subscription_repo
         self._push_history_repo = push_history_repo
         self._sender_provider = sender_provider
+        self._push_job_queue = push_job_queue or SessionPushQueue()
 
     async def dispatch_to_feed_subscribers(
         self,
@@ -66,6 +71,7 @@ class NotificationDispatcher:
         feed_link: str = "",
         media_urls: list[str] | None = None,
         entry_guid: str | None = None,
+        subscription_ids: list[int] | None = None,
     ) -> dict[str, int]:
         """
         将条目分发给 Feed 的所有订阅者
@@ -79,6 +85,7 @@ class NotificationDispatcher:
             feed_link: Feed 链接
             media_urls: 媒体 URL 列表
             entry_guid: 条目 GUID
+            subscription_ids: 限定分发的订阅 ID；为空时分发到所有活跃订阅
 
         Returns:
             统计信息字典 {success: x, failed: y, pending: z}
@@ -87,8 +94,18 @@ class NotificationDispatcher:
 
         # 1. 获取 Feed 的所有启用订阅
         subscriptions = await self._subscription_repo.get_active_by_feed_id(feed_id)
+        if subscription_ids is not None:
+            wanted = set(subscription_ids)
+            subscriptions = [sub for sub in subscriptions if sub.id in wanted]
         if not subscriptions:
-            logger.debug("Feed %s 没有活跃的订阅", feed_id)
+            if subscription_ids is None:
+                logger.debug("Feed %s 没有活跃的订阅", feed_id)
+            else:
+                logger.debug(
+                    "Feed %s 没有匹配的活跃订阅: %s",
+                    feed_id,
+                    subscription_ids,
+                )
             return stats
 
         logger.info(
@@ -145,17 +162,21 @@ class NotificationDispatcher:
                 history = await self._push_history_repo.save(history)
 
                 # 3. 调用消息发送器发送消息
-                result = await self._send_notification(
+                result = await self.send_to_session(
                     subscription=sub,
                     content=content,
                     media_urls=media_urls,
-                    history=history,
+                    job_description=f"feed={feed_id}, sub={sub.id}",
                 )
 
                 # 4. 更新推送状态
                 if result["ok"]:
                     history.mark_success()
                     stats["success"] += 1
+                elif result.get("cancelled"):
+                    history.mark_failed(result.get("error", "Cancelled by /rss_stop"))
+                    history.max_retries = 0
+                    stats["failed"] += 1
                 else:
                     # 首次失败不增加重试计数
                     history.record_first_failure(result.get("error", "Unknown error"))
@@ -183,13 +204,13 @@ class NotificationDispatcher:
         )
         return stats
 
-    async def _send_notification(
+    async def send_to_session(
         self,
         subscription,
         content: str,
         media_urls: list[str] | None,
-        history: PushHistory,
-    ) -> dict:
+        job_description: str = "",
+    ) -> dict[str, Any]:
         """
         发送通知到指定订阅
 
@@ -197,7 +218,7 @@ class NotificationDispatcher:
             subscription: 订阅对象
             content: 消息内容
             media_urls: 媒体 URL 列表
-            history: 推送历史记录
+            job_description: 任务描述，用于队列和日志
 
         Returns:
             发送结果 {"ok": bool, "error": str}
@@ -217,18 +238,62 @@ class NotificationDispatcher:
             if media_urls:
                 media_items = [("image", url) for url in media_urls]
 
-            result = await sender.send_to_user(
-                SendRequest(
-                    session_id=target_session,
-                    message=content,
-                    media=media_items if media_items else None,
-                ),
-                context=MessageContext(platform_name=subscription.platform_name or ""),
+            async def _send(job: PushJob):
+                logger.debug(
+                    "开始 RSS 推送任务: job_id=%s, session=%s, sub=%s",
+                    job.job_id,
+                    target_session,
+                    subscription.id,
+                )
+                return await sender.send_to_user(
+                    SendRequest(
+                        session_id=target_session,
+                        message=content,
+                        media=media_items if media_items else None,
+                    ),
+                    context=MessageContext(
+                        platform_name=subscription.platform_name or ""
+                    ),
+                )
+
+            job_result = await self._push_job_queue.enqueue(
+                target_session,
+                _send,
+                description=job_description,
             )
 
+            if job_result.cancelled:
+                logger.info(
+                    "RSS 推送任务已取消: job_id=%s, session=%s, sub=%s",
+                    job_result.job_id,
+                    target_session,
+                    subscription.id,
+                )
+                return {
+                    "ok": False,
+                    "cancelled": True,
+                    "error": f"Cancelled by /rss_stop (job_id={job_result.job_id})",
+                    "job_id": job_result.job_id,
+                }
+
+            if not job_result.ok or job_result.value is None:
+                return {
+                    "ok": False,
+                    "error": job_result.error or "Push job failed",
+                    "job_id": job_result.job_id,
+                }
+
+            result = job_result.value
+            logger.debug(
+                "RSS 推送任务完成: job_id=%s, session=%s, ok=%s",
+                job_result.job_id,
+                target_session,
+                result.ok,
+            )
             return {
                 "ok": result.ok,
                 "error": result.detail if not result.ok else "",
+                "job_id": job_result.job_id,
             }
 
         except Exception as e:
@@ -269,17 +334,21 @@ class NotificationDispatcher:
                     continue
 
                 # 重新发送
-                result = await self._send_notification(
+                result = await self.send_to_session(
                     subscription=sub,
                     content=history.content,
                     media_urls=None,  # 重试时不重新下载媒体
-                    history=history,
+                    job_description=f"retry history={history.id}",
                 )
 
                 error_msg = result.get("error", "")
                 if result["ok"]:
                     history.mark_success()
                     stats["success"] += 1
+                elif result.get("cancelled"):
+                    history.mark_failed(result.get("error", "Cancelled by /rss_stop"))
+                    history.max_retries = 0
+                    stats["failed"] += 1
                 elif is_unrecoverable_error(error_msg):
                     # 不可恢复错误：直接标记为最终失败，不再重试
                     history.record_first_failure(error_msg)

--- a/src/application/services/session_push_queue.py
+++ b/src/application/services/session_push_queue.py
@@ -12,6 +12,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import count
+from threading import RLock
 from typing import Generic, TypeVar
 
 T = TypeVar("T")
@@ -70,16 +71,29 @@ class SessionPushQueue:
     def __init__(self) -> None:
         self._states: dict[str, _SessionQueueState] = {}
         self._counter = count(1)
+        self._state_guard = RLock()
 
     def _next_job_id(self) -> str:
         return f"rss-{next(self._counter):06d}"
 
     def _state_for(self, session_id: str) -> _SessionQueueState:
-        state = self._states.get(session_id)
-        if state is None:
-            state = _SessionQueueState()
-            self._states[session_id] = state
-        return state
+        with self._state_guard:
+            state = self._states.get(session_id)
+            if state is None:
+                state = _SessionQueueState()
+                self._states[session_id] = state
+            return state
+
+    def _cleanup_state_if_idle(
+        self, session_id: str, state: _SessionQueueState
+    ) -> None:
+        """Remove per-session state when there is no active or queued work."""
+        if (
+            state.queued_count == 0
+            and state.current_job is None
+            and state.current_task is None
+        ):
+            self._states.pop(session_id, None)
 
     async def enqueue(
         self,
@@ -90,23 +104,25 @@ class SessionPushQueue:
     ) -> PushJobResult[T]:
         """Queue a push job for a session and wait for its result."""
         state = self._state_for(session_id)
-        job = PushJob(
-            job_id=self._next_job_id(),
-            session_id=session_id,
-            description=description,
-            queued_before=state.queued_count,
-        )
-
-        state.queued_count += 1
+        with self._state_guard:
+            job = PushJob(
+                job_id=self._next_job_id(),
+                session_id=session_id,
+                description=description,
+                queued_before=state.queued_count,
+            )
+            state.queued_count += 1
         try:
             async with state.lock:
-                state.queued_count -= 1
-                job.status = "running"
-                job.started_at = datetime.now(timezone.utc)
-                state.current_job = job
+                with self._state_guard:
+                    state.queued_count -= 1
+                    job.status = "running"
+                    job.started_at = datetime.now(timezone.utc)
 
                 task = asyncio.create_task(work(job))
-                state.current_task = task
+                with self._state_guard:
+                    state.current_job = job
+                    state.current_task = task
                 try:
                     value = await task
                 except asyncio.CancelledError:
@@ -139,58 +155,78 @@ class SessionPushQueue:
                     value=value,
                 )
         finally:
-            if state.current_job is job:
-                state.current_job = None
-                state.current_task = None
+            with self._state_guard:
+                if state.current_job is job:
+                    state.current_job = None
+                    state.current_task = None
+                self._cleanup_state_if_idle(session_id, state)
 
     def stop_current(self, session_id: str) -> StopPushJobResult:
-        """Cancel the currently running push job for a session."""
-        state = self._states.get(session_id)
-        if state is None or state.current_job is None:
-            return StopPushJobResult(
-                stopped=False,
-                session_id=session_id,
-                message="当前会话没有正在运行的 RSS 推送任务",
-            )
+        """Cancel the currently running push job for a session.
 
-        job = state.current_job
-        task = state.current_task
-        if task is None or task.done():
+        The queue is single-process and in-memory. This method uses a short
+        synchronous guard because command handlers call it without awaiting.
+        It may observe a just-finished task before `enqueue` has run its final
+        cleanup; in that case it reports that no running job exists and lets
+        the enqueue finalizer remove idle state.
+        """
+        with self._state_guard:
+            state = self._states.get(session_id)
+            if state is None or state.current_job is None:
+                if state is not None:
+                    self._cleanup_state_if_idle(session_id, state)
+                return StopPushJobResult(
+                    stopped=False,
+                    session_id=session_id,
+                    message="当前会话没有正在运行的 RSS 推送任务",
+                )
+
+            job = state.current_job
+            task = state.current_task
+            if task is None or task.done():
+                self._cleanup_state_if_idle(session_id, state)
+                return StopPushJobResult(
+                    stopped=False,
+                    session_id=session_id,
+                    queued_count=state.queued_count,
+                    message="当前会话没有正在运行的 RSS 推送任务",
+                )
+
+            job.cancel_requested = True
+            task.cancel()
             return StopPushJobResult(
-                stopped=False,
+                stopped=True,
                 session_id=session_id,
+                job_id=job.job_id,
                 queued_count=state.queued_count,
-                message="当前会话没有正在运行的 RSS 推送任务",
+                message=f"已请求停止 RSS 推送任务 {job.job_id}",
             )
-
-        job.cancel_requested = True
-        task.cancel()
-        return StopPushJobResult(
-            stopped=True,
-            session_id=session_id,
-            job_id=job.job_id,
-            queued_count=state.queued_count,
-            message=f"已请求停止 RSS 推送任务 {job.job_id}",
-        )
 
     def get_current_job(self, session_id: str) -> PushJob | None:
         """Return the currently running job for a session, if any."""
-        state = self._states.get(session_id)
-        return state.current_job if state else None
+        with self._state_guard:
+            state = self._states.get(session_id)
+            return state.current_job if state else None
 
     def get_queued_count(self, session_id: str) -> int:
         """Return the number of queued jobs for a session."""
-        state = self._states.get(session_id)
-        return state.queued_count if state else 0
+        with self._state_guard:
+            state = self._states.get(session_id)
+            return state.queued_count if state else 0
 
     async def stop_all(self) -> None:
         """Cancel all active jobs, typically during plugin shutdown."""
         tasks = []
-        for state in self._states.values():
-            if state.current_job:
-                state.current_job.cancel_requested = True
-            if state.current_task and not state.current_task.done():
-                state.current_task.cancel()
-                tasks.append(state.current_task)
+        with self._state_guard:
+            states = list(self._states.values())
+            for state in states:
+                if state.current_job:
+                    state.current_job.cancel_requested = True
+                if state.current_task and not state.current_task.done():
+                    state.current_task.cancel()
+                    tasks.append(state.current_task)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        with self._state_guard:
+            for session_id, state in list(self._states.items()):
+                self._cleanup_state_if_idle(session_id, state)

--- a/src/application/services/session_push_queue.py
+++ b/src/application/services/session_push_queue.py
@@ -1,0 +1,196 @@
+"""Session-scoped push job queue.
+
+The queue keeps push delivery serialized per target session while allowing
+different sessions to send concurrently. Jobs are in-memory runtime jobs; push
+history remains the durable audit log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from itertools import count
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class PushJob:
+    """Runtime state for one session push job."""
+
+    job_id: str
+    session_id: str
+    description: str = ""
+    status: str = "queued"
+    queued_before: int = 0
+    cancel_requested: bool = False
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class PushJobResult(Generic[T]):
+    """Result returned after a queued push job finishes."""
+
+    job_id: str
+    session_id: str
+    ok: bool
+    cancelled: bool = False
+    error: str = ""
+    value: T | None = None
+
+
+@dataclass(frozen=True)
+class StopPushJobResult:
+    """Result returned by a stop request."""
+
+    stopped: bool
+    session_id: str
+    job_id: str | None = None
+    queued_count: int = 0
+    message: str = ""
+
+
+@dataclass
+class _SessionQueueState:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    current_job: PushJob | None = None
+    current_task: asyncio.Task | None = None
+    queued_count: int = 0
+
+
+class SessionPushQueue:
+    """Serialize push jobs per session and allow cancelling the active job."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, _SessionQueueState] = {}
+        self._counter = count(1)
+
+    def _next_job_id(self) -> str:
+        return f"rss-{next(self._counter):06d}"
+
+    def _state_for(self, session_id: str) -> _SessionQueueState:
+        state = self._states.get(session_id)
+        if state is None:
+            state = _SessionQueueState()
+            self._states[session_id] = state
+        return state
+
+    async def enqueue(
+        self,
+        session_id: str,
+        work: Callable[[PushJob], Awaitable[T]],
+        *,
+        description: str = "",
+    ) -> PushJobResult[T]:
+        """Queue a push job for a session and wait for its result."""
+        state = self._state_for(session_id)
+        job = PushJob(
+            job_id=self._next_job_id(),
+            session_id=session_id,
+            description=description,
+            queued_before=state.queued_count,
+        )
+
+        state.queued_count += 1
+        try:
+            async with state.lock:
+                state.queued_count -= 1
+                job.status = "running"
+                job.started_at = datetime.now(timezone.utc)
+                state.current_job = job
+
+                task = asyncio.create_task(work(job))
+                state.current_task = task
+                try:
+                    value = await task
+                except asyncio.CancelledError:
+                    job.status = "cancelled"
+                    job.completed_at = datetime.now(timezone.utc)
+                    return PushJobResult(
+                        job_id=job.job_id,
+                        session_id=session_id,
+                        ok=False,
+                        cancelled=True,
+                        error="job cancelled",
+                    )
+                except Exception as ex:
+                    job.status = "failed"
+                    job.error = str(ex)
+                    job.completed_at = datetime.now(timezone.utc)
+                    return PushJobResult(
+                        job_id=job.job_id,
+                        session_id=session_id,
+                        ok=False,
+                        error=str(ex),
+                    )
+
+                job.status = "completed"
+                job.completed_at = datetime.now(timezone.utc)
+                return PushJobResult(
+                    job_id=job.job_id,
+                    session_id=session_id,
+                    ok=True,
+                    value=value,
+                )
+        finally:
+            if state.current_job is job:
+                state.current_job = None
+                state.current_task = None
+
+    def stop_current(self, session_id: str) -> StopPushJobResult:
+        """Cancel the currently running push job for a session."""
+        state = self._states.get(session_id)
+        if state is None or state.current_job is None:
+            return StopPushJobResult(
+                stopped=False,
+                session_id=session_id,
+                message="当前会话没有正在运行的 RSS 推送任务",
+            )
+
+        job = state.current_job
+        task = state.current_task
+        if task is None or task.done():
+            return StopPushJobResult(
+                stopped=False,
+                session_id=session_id,
+                queued_count=state.queued_count,
+                message="当前会话没有正在运行的 RSS 推送任务",
+            )
+
+        job.cancel_requested = True
+        task.cancel()
+        return StopPushJobResult(
+            stopped=True,
+            session_id=session_id,
+            job_id=job.job_id,
+            queued_count=state.queued_count,
+            message=f"已请求停止 RSS 推送任务 {job.job_id}",
+        )
+
+    def get_current_job(self, session_id: str) -> PushJob | None:
+        """Return the currently running job for a session, if any."""
+        state = self._states.get(session_id)
+        return state.current_job if state else None
+
+    def get_queued_count(self, session_id: str) -> int:
+        """Return the number of queued jobs for a session."""
+        state = self._states.get(session_id)
+        return state.queued_count if state else 0
+
+    async def stop_all(self) -> None:
+        """Cancel all active jobs, typically during plugin shutdown."""
+        tasks = []
+        for state in self._states.values():
+            if state.current_job:
+                state.current_job.cancel_requested = True
+            if state.current_task and not state.current_task.done():
+                state.current_task.cancel()
+                tasks.append(state.current_task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/src/domain/entities/content_types.py
+++ b/src/domain/entities/content_types.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Union
 
 from pydantic import BaseModel, Field
 
@@ -87,15 +86,15 @@ class MentionContent(ContentNode):
 
 
 # 内容节点联合类型
-ContentNodeType = Union[
-    TextContent,
-    LinkContent,
-    ImageContent,
-    VideoContent,
-    AudioContent,
-    FileContent,
-    MentionContent,
-]
+ContentNodeType = (
+    TextContent
+    | LinkContent
+    | ImageContent
+    | VideoContent
+    | AudioContent
+    | FileContent
+    | MentionContent
+)
 
 
 class HtmlNode(BaseModel):

--- a/src/domain/entities/feed.py
+++ b/src/domain/entities/feed.py
@@ -12,6 +12,36 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, Field, field_validator
 
 
+def normalize_entry_hashes(value: Any) -> list[list[str]] | None:
+    """Accept legacy flat hash lists and normalize to grouped storage."""
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        return None
+    if not value:
+        return []
+    if isinstance(value[0], list):
+        return [
+            [str(item) for item in group if item]
+            for group in value
+            if isinstance(group, list) and group
+        ]
+
+    groups: list[list[str]] = []
+    current: list[str] = []
+    for raw in value:
+        item = str(raw or "")
+        if not item:
+            continue
+        if item.startswith("sid:") and current:
+            groups.append(current)
+            current = []
+        current.append(item)
+    if current:
+        groups.append(current)
+    return groups
+
+
 class Feed(BaseModel):
     """
     Feed 领域实体
@@ -45,33 +75,7 @@ class Feed(BaseModel):
     @field_validator("entry_hashes", mode="before")
     @classmethod
     def _normalize_entry_hashes(cls, value: Any) -> list[list[str]] | None:
-        """Accept legacy flat hash lists and normalize to grouped storage."""
-        if value is None:
-            return None
-        if not isinstance(value, list):
-            return None
-        if not value:
-            return []
-        if isinstance(value[0], list):
-            return [
-                [str(item) for item in group if item]
-                for group in value
-                if isinstance(group, list) and group
-            ]
-
-        groups: list[list[str]] = []
-        current: list[str] = []
-        for raw in value:
-            item = str(raw or "")
-            if not item:
-                continue
-            if item.startswith("sid:") and current:
-                groups.append(current)
-                current = []
-            current.append(item)
-        if current:
-            groups.append(current)
-        return groups
+        return normalize_entry_hashes(value)
 
     def _validate_link(self) -> None:
         """

--- a/src/domain/entities/feed.py
+++ b/src/domain/entities/feed.py
@@ -6,9 +6,10 @@ Feed 领域实体
 """
 
 from datetime import datetime, timezone
+from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class Feed(BaseModel):
@@ -40,6 +41,37 @@ class Feed(BaseModel):
         self._validate_link()
         if not self.title:
             self.title = self.link
+
+    @field_validator("entry_hashes", mode="before")
+    @classmethod
+    def _normalize_entry_hashes(cls, value: Any) -> list[list[str]] | None:
+        """Accept legacy flat hash lists and normalize to grouped storage."""
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            return None
+        if not value:
+            return []
+        if isinstance(value[0], list):
+            return [
+                [str(item) for item in group if item]
+                for group in value
+                if isinstance(group, list) and group
+            ]
+
+        groups: list[list[str]] = []
+        current: list[str] = []
+        for raw in value:
+            item = str(raw or "")
+            if not item:
+                continue
+            if item.startswith("sid:") and current:
+                groups.append(current)
+                current = []
+            current.append(item)
+        if current:
+            groups.append(current)
+        return groups
 
     def _validate_link(self) -> None:
         """

--- a/src/domain/entities/push_history.py
+++ b/src/domain/entities/push_history.py
@@ -6,6 +6,7 @@
 """
 
 from datetime import datetime, timezone
+
 from pydantic import BaseModel, Field
 
 

--- a/src/domain/entities/user.py
+++ b/src/domain/entities/user.py
@@ -6,6 +6,7 @@
 """
 
 from datetime import datetime, timezone
+
 from pydantic import BaseModel, Field
 
 from ..constants import INHERIT_VALUE

--- a/src/domain/value_objects/update_interval.py
+++ b/src/domain/value_objects/update_interval.py
@@ -7,7 +7,6 @@
 
 from pydantic import BaseModel, Field
 
-
 MIN_INTERVAL_MINUTES = 1
 MAX_INTERVAL_MINUTES = 1440  # 24小时
 

--- a/src/infrastructure/config/__init__.py
+++ b/src/infrastructure/config/__init__.py
@@ -4,8 +4,8 @@
 """
 
 from .config_manager import (
-    BasicConfig,
     BaiduTranslateConfig,
+    BasicConfig,
     FFmpegConfig,
     GlobalConfig,
     GoogleTranslateConfig,

--- a/src/infrastructure/fetcher/__init__.py
+++ b/src/infrastructure/fetcher/__init__.py
@@ -3,28 +3,29 @@
 提供通用 HTTP 抓取和 RSS 数据源处理能力。
 """
 
-from ...application.dto import WebFeed
+from ...application.dto import WebFeed as WebFeed
 from .http import HttpFetcher
 from .rss import (
-    Enclosure,
-    EntryParsed,
-    FeedDiscoverer,
-    FeedDiscoveryResult,
-    RSSFeedFetcher,
-    RSSParser,
+    Enclosure as Enclosure,
 )
-
-# 向后兼容：保持旧路径引用有效
-from ..fetcher.rss import (
-    Enclosure as _EnclosureAlias,
-    EntryParsed as _EntryParsedAlias,
-    FeedDiscoverer as _FeedDiscovererAlias,
-    FeedDiscoveryResult as _FeedDiscoveryResultAlias,
-    RSSFeedFetcher as _RSSFeedFetcherAlias,
-    RSSParser as _RSSParserAlias,
+from .rss import (
+    EntryParsed as EntryParsed,
+)
+from .rss import (
+    FeedDiscoverer as FeedDiscoverer,
+)
+from .rss import (
+    FeedDiscoveryResult as FeedDiscoveryResult,
+)
+from .rss import (
+    RSSFeedFetcher as RSSFeedFetcher,
+)
+from .rss import (
+    RSSParser as RSSParser,
 )
 
 __all__ = [
+    "WebFeed",
     "HttpFetcher",
     "RSSFeedFetcher",
     "RSSParser",

--- a/src/infrastructure/media/__init__.py
+++ b/src/infrastructure/media/__init__.py
@@ -3,8 +3,10 @@
 提供媒体文件下载、缓存管理和格式转换功能。
 """
 
+from .fingerprint_service import HttpMediaFingerprintService
 from .media_downloader import MediaDownloader
 
 __all__ = [
+    "HttpMediaFingerprintService",
     "MediaDownloader",
 ]

--- a/src/infrastructure/media/fingerprint_service.py
+++ b/src/infrastructure/media/fingerprint_service.py
@@ -1,0 +1,63 @@
+"""Infrastructure media fingerprint adapter."""
+
+from __future__ import annotations
+
+import hashlib
+
+import aiohttp
+
+from ..utils import get_logger
+
+logger = get_logger()
+
+
+class HttpMediaFingerprintService:
+    """Download small media samples and calculate SHA256 fingerprints."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: int = 10,
+        max_bytes: int = 5 * 1024 * 1024,
+        proxy: str = "",
+        max_urls: int = 3,
+    ) -> None:
+        self._timeout_seconds = max(1, timeout_seconds)
+        self._max_bytes = max(1, max_bytes)
+        self._proxy = proxy.strip()
+        self._max_urls = max(1, max_urls)
+
+    async def fingerprint_urls(self, urls: list[str]) -> list[str]:
+        hashes: list[str] = []
+        timeout = aiohttp.ClientTimeout(total=self._timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            for url in urls[: self._max_urls]:
+                digest = await self._fingerprint_url(session, url)
+                if digest:
+                    hashes.append(f"media:{digest}")
+        return hashes
+
+    async def _fingerprint_url(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+    ) -> str | None:
+        if not url.startswith(("http://", "https://")):
+            return None
+
+        try:
+            async with session.get(url, proxy=self._proxy or None) as resp:
+                if resp.status != 200:
+                    return None
+
+                size = 0
+                sha = hashlib.sha256()
+                async for chunk in resp.content.iter_chunked(8192):
+                    size += len(chunk)
+                    if size > self._max_bytes:
+                        return None
+                    sha.update(chunk)
+                return sha.hexdigest() if size > 0 else None
+        except Exception as ex:
+            logger.debug("Media fingerprint failed: url=%s, err=%s", url, ex)
+            return None

--- a/src/infrastructure/messaging/notification_service.py
+++ b/src/infrastructure/messaging/notification_service.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ...application.ports import MessageContext, MessageSenderProvider, SendRequest
+from ...application.ports import MessageSenderProvider
 from ...application.services.notification_dispatcher import NotificationDispatcher
+from ...application.services.session_push_queue import SessionPushQueue
 from ...domain.repositories.push_history_repository import PushHistoryRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
 from ..utils import get_logger
@@ -34,12 +35,15 @@ class NotificationServiceImpl:
         subscription_repo: SubscriptionRepository,
         push_history_repo: PushHistoryRepository,
         sender_provider: MessageSenderProvider | None = None,
+        push_job_queue: SessionPushQueue | None = None,
     ):
         self._sender_provider = sender_provider or InfrastructureMessageSenderProvider()
+        self._push_job_queue = push_job_queue or SessionPushQueue()
         self._dispatcher = NotificationDispatcher(
             subscription_repo=subscription_repo,
             push_history_repo=push_history_repo,
             sender_provider=self._sender_provider,
+            push_job_queue=self._push_job_queue,
         )
 
     async def notify_feed_update(
@@ -129,14 +133,11 @@ class NotificationServiceImpl:
             if not sub.target_session:
                 continue
 
-            sender = self._sender_provider.get(sub.platform_name)
-            context = MessageContext(platform_name=sub.platform_name or "")
-            await sender.send_to_user(
-                SendRequest(
-                    session_id=sub.target_session,
-                    message=content,
-                ),
-                context=context,
+            await self._dispatcher.send_to_session(
+                subscription=sub,
+                content=content,
+                media_urls=None,
+                job_description=f"feed-error feed={feed.id}, sub={sub.id}",
             )
 
 
@@ -147,6 +148,7 @@ def get_notification_service(
     subscription_repo: SubscriptionRepository | None = None,
     push_history_repo: PushHistoryRepository | None = None,
     sender_provider: MessageSenderProvider | None = None,
+    push_job_queue: SessionPushQueue | None = None,
 ) -> NotificationServiceImpl:
     """获取通知服务实例
 
@@ -167,6 +169,7 @@ def get_notification_service(
             subscription_repo=subscription_repo,
             push_history_repo=push_history_repo,
             sender_provider=sender_provider,
+            push_job_queue=push_job_queue,
         )
     return _notification_service_instance
 

--- a/src/infrastructure/persistence/__init__.py
+++ b/src/infrastructure/persistence/__init__.py
@@ -7,8 +7,8 @@ from .database import DatabaseManager, RSSHubBaseModel, get_database
 from .feed_repository_impl import FeedRepositoryImpl, get_feed_repository
 from .models import (
     EFFECTIVE_OPTION_KEYS,
-    FeedORM,
     INHERIT_VALUE,
+    FeedORM,
     MigrationRecordORM,
     PushHistoryORM,
     SubORM,

--- a/src/infrastructure/persistence/subscription_repository_impl.py
+++ b/src/infrastructure/persistence/subscription_repository_impl.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 from sqlmodel import asc, select
 
+from ...domain.entities.subscription import Subscription
+from ..utils import get_logger
 from .database import get_database
 from .models import SubORM
-from ..utils import get_logger
-from ...domain.entities.subscription import Subscription
 
 logger = get_logger()
 

--- a/src/infrastructure/persistence/user_repository_impl.py
+++ b/src/infrastructure/persistence/user_repository_impl.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-
 from ...domain.entities.user import User
 from ...domain.repositories.user_repository import UserRepository
 from ..utils import get_logger

--- a/src/infrastructure/pipeline/filters/__init__.py
+++ b/src/infrastructure/pipeline/filters/__init__.py
@@ -125,11 +125,11 @@ class FilterChain:
 
 
 # 延迟导入避免循环依赖；具体过滤器实现在 base.py 中。
-from .base import (  # noqa: E402
-    KeywordFilter,
-    LLMEnrichFilter,
-    LLMFilter,
-    PassThroughFilter,
-    TranslationFilter,
-    build_default_chain,
+from .base import (  # noqa: E402,I001
+    KeywordFilter as KeywordFilter,
+    LLMEnrichFilter as LLMEnrichFilter,
+    LLMFilter as LLMFilter,
+    PassThroughFilter as PassThroughFilter,
+    TranslationFilter as TranslationFilter,
+    build_default_chain as build_default_chain,
 )

--- a/src/infrastructure/pipeline/filters/base.py
+++ b/src/infrastructure/pipeline/filters/base.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...utils import get_logger
 from . import BaseFilter, FilterContext, FilterResult
+
+if TYPE_CHECKING:
+    from . import FilterChain
 
 logger = get_logger()
 

--- a/src/infrastructure/pipeline/formatter.py
+++ b/src/infrastructure/pipeline/formatter.py
@@ -6,8 +6,8 @@ senders 只管发送，排序逻辑全部集中在 Formatter 中。
 
 from __future__ import annotations
 
-from urllib.parse import unquote, urlparse
 from typing import TYPE_CHECKING
+from urllib.parse import unquote, urlparse
 
 if TYPE_CHECKING:
     from ..messaging.senders.types import PreparedMedia
@@ -22,7 +22,7 @@ class MessageFormatter:
 
     def build_chain(
         self,
-        prepared_media: list["PreparedMedia"] | None,
+        prepared_media: list[PreparedMedia] | None,
         text: str,
         failed_urls: list[str],
         platform: str = "",
@@ -57,7 +57,7 @@ class MessageFormatter:
 
     def _build_default_chain(
         self,
-        prepared_media: list["PreparedMedia"] | None,
+        prepared_media: list[PreparedMedia] | None,
         text: str,
         failed_urls: list[str],
     ) -> list:
@@ -103,7 +103,7 @@ class MessageFormatter:
 
     def _build_telegram_chain(
         self,
-        prepared_media: list["PreparedMedia"] | None,
+        prepared_media: list[PreparedMedia] | None,
         text: str,
         failed_urls: list[str],
     ) -> list:

--- a/src/infrastructure/rss/__init__.py
+++ b/src/infrastructure/rss/__init__.py
@@ -4,6 +4,7 @@
 请优先引用 ``from ...infrastructure.fetcher import ...``。
 """
 
+from ...application.dto import WebFeed
 from ..fetcher.rss import (
     Enclosure,
     EntryParsed,
@@ -12,7 +13,6 @@ from ..fetcher.rss import (
     RSSFeedFetcher,
     RSSParser,
 )
-from ...application.dto import WebFeed
 
 __all__ = [
     "WebFeed",

--- a/src/infrastructure/schedule/rss_scheduler.py
+++ b/src/infrastructure/schedule/rss_scheduler.py
@@ -1,45 +1,36 @@
-"""RSS 调度器模块
+"""RSS scheduler adapter.
 
-负责定时检查订阅的 RSS 源并触发更新推送。
-基于订阅维度调度，实现会话/订阅级 interval 生效。
+This module owns only timing concerns: finding due subscriptions, grouping them
+by feed, triggering the application polling use case, and updating the next
+check time. Fetching, parsing, deduplication, and notification dispatch live in
+FeedPollingService.
 """
 
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import zlib
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from email.utils import format_datetime
-from itertools import chain
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol
 
-import aiohttp
 from sqlmodel import or_, select
 
-from ...application.ports import MessageSenderProvider
-from ...application.services.notification_dispatcher import NotificationDispatcher
-from ..fetcher.rss import RSSFeedFetcher
-from ..messaging.senders.provider import InfrastructureMessageSenderProvider
 from ..persistence.database import get_database
 from ..persistence.models import FeedORM, SubORM
-from ..persistence.push_history_repository_impl import get_push_history_repository
-from ..persistence.subscription_repository_impl import get_subscription_repository
 from ..utils import get_logger
 from ..utils.lock import locked
-from ..utils.normalizer import normalize_identifier, normalize_text
 
 if TYPE_CHECKING:
+    from ...application.services.feed_polling_service import FeedPollingService
+    from ...application.services.notification_dispatcher import NotificationDispatcher
     from ...domain.entities.feed import Feed
     from ...domain.entities.subscription import Subscription
-    from ...domain.repositories.push_history_repository import PushHistoryRepository
-    from ...domain.repositories.subscription_repository import SubscriptionRepository
 
 logger = get_logger()
 
 
 class NotificationService(Protocol):
-    """通知服务协议（由应用层实现）"""
+    """Legacy notification protocol kept for compatibility with old imports."""
 
     async def notify_feed_update(
         self,
@@ -47,16 +38,7 @@ class NotificationService(Protocol):
         subscriptions: list[Subscription],
         entries: list[dict[str, Any]],
     ) -> bool:
-        """通知订阅者 Feed 更新
-
-        Args:
-            feed: 更新的 Feed
-            subscriptions: 相关订阅列表
-            entries: 新条目列表
-
-        Returns:
-            是否成功
-        """
+        """Notify subscribers about feed updates."""
         ...
 
     async def notify_feed_error(
@@ -65,14 +47,17 @@ class NotificationService(Protocol):
         subscriptions: list[Subscription],
         error: str,
     ) -> None:
-        """通知订阅者 Feed 错误
-
-        Args:
-            feed: 出错的 Feed
-            subscriptions: 相关订阅列表
-            error: 错误描述
-        """
+        """Notify subscribers about feed polling errors."""
         ...
+
+
+@dataclass(frozen=True)
+class DueSubscription:
+    """Subscription selected by the scheduler for the current tick."""
+
+    id: int
+    feed_id: int
+    interval: int
 
 
 class SchedulerStats:
@@ -124,70 +109,28 @@ class SchedulerStats:
 
 
 class RSSScheduler:
-    """RSS 调度器，负责定时检查订阅源并触发推送"""
+    """RSS 调度器，负责定时触发到期订阅的 Feed 轮询"""
 
-    TIMEOUT: Final = 300
-    HASH_HISTORY_MIN: Final = 200
-    HASH_HISTORY_MULTIPLIER: Final = 2
-    HASH_HISTORY_HARD_LIMIT: Final = 5000
-    HASH_HISTORY_ABSOLUTE_MAX: Final = 20000
-    TRACKING_QUERY_PARAMS: Final = frozenset(
-        {
-            "utm_source",
-            "utm_medium",
-            "utm_campaign",
-            "utm_term",
-            "utm_content",
-            "utm_id",
-            "gclid",
-            "fbclid",
-            "mc_cid",
-            "mc_eid",
-            "spm",
-            "ref",
-            "ref_src",
-        }
-    )
+    TIMEOUT = 300
 
     def __init__(
         self,
-        fetcher: RSSFeedFetcher | None = None,
+        *,
+        feed_polling_service: FeedPollingService | None = None,
+        notification_dispatcher: NotificationDispatcher | None = None,
         notification_service: NotificationService | None = None,
-        hash_history_min: int = 200,
-        hash_history_multiplier: int = 2,
-        hash_history_hard_limit: int = 5000,
-        bootstrap_skip_history: bool = True,
-        history_entry_limit: int = 0,
         default_interval: int = 10,
         history_retention_days: int = 30,
-        sender_provider: MessageSenderProvider | None = None,
+        **_: Any,
     ) -> None:
-        self._fetcher = fetcher or RSSFeedFetcher()
-        self._notification_service = notification_service
+        self._feed_polling_service = feed_polling_service
+        self._notification_dispatcher = notification_dispatcher
+        self._legacy_notification_service = notification_service
         self._stats = SchedulerStats()
         self._running = False
         self._bg_task: asyncio.Task | None = None
-        self._hash_history_min = max(1, hash_history_min)
-        self._hash_history_multiplier = max(1, hash_history_multiplier)
-        self._hash_history_hard_limit = max(
-            self._hash_history_min, hash_history_hard_limit
-        )
-        self._bootstrap_skip_history = bootstrap_skip_history
-        self._history_entry_limit = max(0, history_entry_limit)
         self._default_interval = max(1, default_interval)
         self._history_retention_days = max(1, history_retention_days)
-        self._sender_provider = sender_provider or InfrastructureMessageSenderProvider()
-
-        # 初始化 NotificationDispatcher 用于重试机制
-        self._notification_dispatcher = NotificationDispatcher(
-            subscription_repo=cast(
-                "SubscriptionRepository", get_subscription_repository()
-            ),
-            push_history_repo=cast(
-                "PushHistoryRepository", get_push_history_repository()
-            ),
-            sender_provider=self._sender_provider,
-        )
 
     async def start(self) -> None:
         """启动调度器"""
@@ -203,7 +146,6 @@ class RSSScheduler:
                 await self._bg_task
             except asyncio.CancelledError:
                 pass
-        await self._fetcher.close()
         logger.info("RSS调度器已停止")
 
     async def run_periodic_task(self) -> None:
@@ -215,7 +157,19 @@ class RSSScheduler:
         if now.minute == 0:
             await self._cleanup_old_records()
 
-        # 处理待重试的推送（每分钟都执行）
+        await self._dispatch_pending_retries()
+
+        try:
+            due_by_feed = await self._load_due_subscriptions(now)
+            for feed_id, due_subs in due_by_feed.items():
+                await self._process_feed_group(feed_id, due_subs)
+        except Exception as ex:
+            logger.error("执行定时任务失败: %s", ex, exc_info=True)
+
+    async def _dispatch_pending_retries(self) -> None:
+        if self._notification_dispatcher is None:
+            return
+
         try:
             retry_stats = await self._notification_dispatcher.dispatch_pending_retries(
                 limit=50
@@ -230,47 +184,11 @@ class RSSScheduler:
         except Exception as e:
             logger.error("处理重试推送失败: %s", e, exc_info=True)
 
-        try:
-            db = get_database()
-            async with db.get_session() as session:
-                stmt = (
-                    select(SubORM)
-                    .join(FeedORM)
-                    .where(
-                        SubORM.state == 1,
-                        FeedORM.state == 1,
-                        or_(
-                            cast(Any, SubORM.next_check_time).is_(None),
-                            SubORM.next_check_time <= now,
-                        ),
-                    )
-                )
-                result = await session.execute(stmt)
-                due_subs = list(result.scalars().all())
-
-                if not due_subs:
-                    return
-
-                # 按 (feed_id, interval) 分组
-                groups: dict[tuple[int, int], list[SubORM]] = {}
-                for sub in due_subs:
-                    if sub.feed_id is None:
-                        continue
-                    effective_interval = self._resolve_interval(sub)
-                    key = (sub.feed_id, effective_interval)
-                    groups.setdefault(key, []).append(sub)
-
-                for (feed_id, interval), subs in groups.items():
-                    feed_orm = await session.get(FeedORM, feed_id)  # type: ignore[arg-type]
-                    if not feed_orm:
-                        continue
-                    await self._process_feed_group(session, feed_orm, subs, interval)
-
-        except Exception as ex:
-            logger.error("执行定时任务失败: %s", ex, exc_info=True)
-
     async def _cleanup_old_records(self) -> None:
         """清理指定天数前的推送历史记录"""
+        if self._notification_dispatcher is None:
+            return
+
         try:
             deleted_count = await self._notification_dispatcher.cleanup_old_records(
                 days=self._history_retention_days
@@ -284,470 +202,109 @@ class RSSScheduler:
         except Exception as e:
             logger.error("清理推送历史记录失败: %s", e, exc_info=True)
 
+    async def _load_due_subscriptions(
+        self,
+        now: datetime,
+    ) -> dict[int, list[DueSubscription]]:
+        db = get_database()
+        due_by_feed: dict[int, list[DueSubscription]] = {}
+
+        async with db.get_session() as session:
+            stmt = (
+                select(SubORM)
+                .join(FeedORM)
+                .where(
+                    SubORM.state == 1,
+                    FeedORM.state == 1,
+                    or_(
+                        SubORM.next_check_time.is_(None),  # type: ignore[attr-defined]
+                        SubORM.next_check_time <= now,
+                    ),
+                )
+            )
+            result = await session.execute(stmt)
+            due_subs = list(result.scalars().all())
+
+        for sub in due_subs:
+            if sub.id is None or sub.feed_id is None:
+                continue
+            due = DueSubscription(
+                id=sub.id,
+                feed_id=sub.feed_id,
+                interval=self._resolve_interval(sub),
+            )
+            due_by_feed.setdefault(sub.feed_id, []).append(due)
+
+        return due_by_feed
+
     def _resolve_interval(self, sub: SubORM) -> int:
         """解析订阅生效的监控间隔"""
         if sub.interval and sub.interval > 0:
             return sub.interval
         return self._default_interval
 
+    @locked("#feed_id")
     async def _process_feed_group(
         self,
-        session,
-        feed: FeedORM,
-        subs: list[SubORM],
-        interval: int,
+        feed_id: int,
+        due_subs: list[DueSubscription],
     ) -> None:
-        """处理一个 Feed 组"""
-        if feed.id is None:
+        """Trigger the polling use case for one feed and update schedule fields."""
+        if not due_subs:
             return
-        await self._do_monitor_feed(session, feed, subs, interval)
-
-    @locked("#feed.id")
-    async def _do_monitor_feed(
-        self,
-        session,
-        feed: FeedORM,
-        subs: list[SubORM],
-        interval: int,
-    ) -> None:
-        """实际监控 Feed（已加锁）"""
-        headers = {
-            "If-Modified-Since": format_datetime(feed.last_modified or feed.updated_at)
-        }
-        if feed.etag:
-            headers["If-None-Match"] = feed.etag
-
-        wf = await self._fetcher.fetch(
-            feed.link,
-            headers=headers,
-            verbose=False,
-        )
-        rss_d = wf.rss_d
-
-        feed_updated_fields: set[str] = set()
-        schedule_action: tuple[str, str | None] = ("success", None)
 
         try:
-            if wf.status == 304:
-                self._stats.cached()
+            if self._feed_polling_service is None:
+                raise RuntimeError("RSSScheduler requires FeedPollingService")
 
-            elif rss_d is None:
-                schedule_action = (
-                    "error",
-                    wf.error.error_name if wf.error else "未知错误",
-                )
-                if self._all_subs_blocked(subs):
-                    feed.state = 0
-                    feed_updated_fields.add("state")
-                self._stats.failed()
-
-            elif not rss_d.entries:
-                schedule_action = ("success", None)
-                self._stats.empty()
-
-            else:
-                etag = wf.etag
-                if etag and etag != feed.etag:
-                    feed.etag = etag
-                    feed_updated_fields.add("etag")
-                    logger.debug("Updated ETag for feed %s: %s", feed.id, etag)
-
-                title = rss_d.feed.get("title", "")
-                if title and title != feed.title:
-                    feed.title = title[:1024]
-                    feed_updated_fields.add("title")
-
-                old_groups = self._migrate_hashes(feed.entry_hashes or [])
-                fetched_entries = len(rss_d.entries)
-                new_groups, updated_entries = self._calculate_update(
-                    old_groups,
-                    rss_d.entries,
-                    feed_link=feed.link,
-                )
-                merged = self._merge_hash_history(
-                    old_groups, new_groups, fetched_entries
-                )
-
-                if not old_groups:
-                    # 首次初始化
-                    feed.last_modified = wf.last_modified
-                    feed.entry_hashes = merged
-                    feed_updated_fields.update({"last_modified", "entry_hashes"})
-
-                    if not updated_entries:
-                        self._stats.not_updated()
-                    elif self._bootstrap_skip_history:
-                        logger.info(
-                            "Feed首次初始化跳过历史: %s, entries=%s",
-                            feed.link,
-                            len(updated_entries),
-                        )
-                        self._stats.not_updated()
-                    else:
-                        await self._send_notifications(feed, subs, updated_entries)
-                        feed.last_modified = wf.last_modified
-                        feed.entry_hashes = merged
-                        feed_updated_fields.update({"last_modified", "entry_hashes"})
-                        self._stats.updated()
-
-                elif not updated_entries:
-                    if merged != old_groups:
-                        feed.entry_hashes = merged
-                        feed_updated_fields.add("entry_hashes")
-                    self._stats.not_updated()
-
-                else:
-                    await self._send_notifications(feed, subs, updated_entries)
-                    feed.last_modified = wf.last_modified
-                    feed.entry_hashes = merged
-                    feed_updated_fields.update({"last_modified", "entry_hashes"})
-                    self._stats.updated()
-
+            result = await self._feed_polling_service.poll_feed_group(
+                feed_id,
+                [sub.id for sub in due_subs],
+                notify_new_entries=True,
+            )
+            self._record_polling_result(result)
+        except Exception as ex:
+            self._stats.failed()
+            logger.error(
+                "Feed 定时轮询失败: feed_id=%s, subs=%s, err=%s",
+                feed_id,
+                [sub.id for sub in due_subs],
+                ex,
+                exc_info=True,
+            )
         finally:
-            if feed_updated_fields:
-                session.add(feed)
-                await session.commit()
-                logger.debug("Feed %s 已更新字段: %s", feed.id, feed_updated_fields)
+            await self._update_next_check_times(due_subs)
 
-        action, reason = schedule_action
-        if action == "success":
-            await self._schedule_after_success(subs, interval)
-        elif action == "error" and reason:
-            await self._schedule_after_error(subs, interval)
-
-    async def _send_notifications(
+    async def _update_next_check_times(
         self,
-        feed: FeedORM,
-        subs: list[SubORM],
-        entries: list[dict],
+        due_subs: list[DueSubscription],
     ) -> None:
-        """发送通知"""
-        if not self._notification_service:
+        """更新订阅的下次检查时间"""
+        if not due_subs:
             return
 
-        # 按时间排序（新到旧）
-        sorted_entries = sorted(
-            entries,
-            key=lambda e: e.get("published_parsed") or e.get("updated_parsed") or (),
-            reverse=True,
-        )
-
-        # 应用历史条目限制
-        if self._history_entry_limit > 0:
-            sorted_entries = sorted_entries[: self._history_entry_limit]
-
-        # 转换为 EntryParsed 对象
-        from ..domain.entities.feed import Feed
-        from ..domain.entities.subscription import Subscription
-
-        feed_entity = Feed(
-            id=feed.id,
-            state=feed.state,
-            link=feed.link,
-            title=feed.title,
-        )
-        subscription_entities = [
-            Subscription(
-                id=sub.id,
-                state=sub.state,
-                user_id=sub.user_id,
-                feed_id=sub.feed_id,
-                title=sub.title or "",
-                target_session=sub.target_session,
-                platform_name=sub.platform_name,
-                interval=sub.interval,
-            )
-            for sub in subs
-        ]
-
-        await self._notification_service.notify_feed_update(
-            feed_entity, subscription_entities, sorted_entries
-        )
-
-    async def _update_next_check_times(self, subs: list[SubORM], interval: int) -> None:
-        """更新订阅的下次检查时间"""
         now = datetime.now(timezone.utc)
         db = get_database()
         async with db.get_session() as session:
-            for sub in subs:
-                if sub.id is None:
-                    continue
-                db_sub = await session.get(SubORM, sub.id)
+            for due in due_subs:
+                db_sub = await session.get(SubORM, due.id)
                 if db_sub:
-                    db_sub.next_check_time = now + timedelta(minutes=interval)
+                    db_sub.next_check_time = now + timedelta(minutes=due.interval)
                     session.add(db_sub)
             await session.commit()
 
-    async def _schedule_after_success(self, subs: list[SubORM], interval: int) -> None:
-        """成功后更新下次检查时间"""
-        await self._update_next_check_times(subs, interval)
+    def _record_polling_result(self, result: Any) -> None:
+        if not result.success:
+            self._stats.failed()
+            return
 
-    async def _schedule_after_error(self, subs: list[SubORM], interval: int) -> None:
-        """失败后更新下次检查时间"""
-        await self._update_next_check_times(subs, interval)
-
-    @staticmethod
-    def _all_subs_blocked(subs: list[SubORM]) -> bool:
-        """检查是否所有订阅都被禁用"""
-        return len(subs) > 0 and all((s.state == 0) for s in subs)
-
-    def _migrate_hashes(self, raw: list) -> list[list[str]]:
-        """将旧格式哈希列表迁移为新格式"""
-        if not raw:
-            return []
-        if isinstance(raw[0], list):
-            return raw
-        groups: list[list[str]] = []
-        current: list[str] = []
-        for h in raw:
-            if h.startswith("sid:") and current:
-                groups.append(current)
-                current = []
-            current.append(h)
-        if current:
-            groups.append(current)
-        return groups
-
-    async def _calculate_update(
-        self,
-        old_groups: list[list[str]],
-        entries: list,
-        feed_link: str | None = None,
-    ) -> tuple[list[list[str]], list]:
-        """计算哪些条目是新的"""
-        old_flat = {h for group in old_groups for h in group if h}
-        known_hashes = set(old_flat)
-        new_groups: list[list[str]] = []
-        updated_entries = []
-
-        for entry in entries:
-            entry_hashes = await self._hash_entry(entry, feed_link)
-            stable_hash = next((h for h in entry_hashes if h.startswith("sid:")), "")
-
-            known_by_identity = bool(stable_hash) and stable_hash in known_hashes
-            known_by_compat = False
-            if not known_by_identity and not stable_hash:
-                known_by_compat = any(h in known_hashes for h in entry_hashes)
-
-            if not (known_by_identity or known_by_compat):
-                updated_entries.append(entry)
-
-            new_groups.append(entry_hashes)
-            if stable_hash:
-                known_hashes.add(stable_hash)
-
-        return new_groups, updated_entries
-
-    async def _hash_entry(self, entry: dict, feed_link: str | None = None) -> list[str]:
-        """计算条目的去重指纹（含文本和媒体内容）"""
-        upstream_material = self._upstream_material(entry)
-        upstream_crc = (
-            hex(zlib.crc32(upstream_material.encode("utf-8", errors="ignore")))[2:]
-            if upstream_material
-            else ""
-        )
-
-        entry_id = normalize_identifier(str(entry.get("id") or entry.get("guid") or ""))
-        link = self._resolve_entry_link(entry, feed_link)
-        title = normalize_text(str(entry.get("title") or ""))
-        summary = normalize_text(
-            str(entry.get("summary") or entry.get("description") or ""),
-            max_length=2048,
-        )
-
-        stable_material = ""
-        if entry_id:
-            stable_material = f"v3|id={entry_id}"
-        elif link:
-            stable_material = f"v3|link={link}"
-        elif title:
-            stable_material = f"v3|title={title}"
-        elif summary:
-            stable_material = f"v3|summary={summary[:256]}"
-
-        content_material = f"v3|title={title}|link={link}|summary={summary[:512]}"
-
-        fingerprints: list[str] = []
-        if stable_material:
-            stable_hash = f"sid:{hashlib.sha256(stable_material.encode()).hexdigest()}"
-            fingerprints.append(stable_hash)
-
-        content_hash = hashlib.sha256(content_material.encode()).hexdigest()
-        if content_hash not in fingerprints:
-            fingerprints.append(content_hash)
-
-        if upstream_crc and upstream_crc not in fingerprints:
-            fingerprints.append(upstream_crc)
-
-        legacy_hash = self._legacy_crc32(entry)
-        if legacy_hash and legacy_hash not in fingerprints:
-            fingerprints.append(legacy_hash)
-
-        # 媒体内容指纹：下载 enclosure 并计算 SHA256
-        media_hashes = await self._media_content_hashes(entry)
-        for mh in media_hashes:
-            if mh not in fingerprints:
-                fingerprints.append(mh)
-
-        return fingerprints
-
-    async def _media_content_hashes(self, entry: dict) -> list[str]:
-        """下载 entry 的媒体内容并计算 SHA256 指纹"""
-        enclosures = entry.get("enclosures") or []
-        if not enclosures:
-            media_list = entry.get("media_content") or []
-            enclosures = [m for m in media_list if isinstance(m, dict)]
-
-        hashes: list[str] = []
-        for enc in enclosures[:3]:  # 最多取 3 个
-            url = str(enc.get("url") or enc.get("href") or "")
-            if not url or not url.startswith("http"):
-                continue
-            mime = str(enc.get("type") or "")
-            # 只处理图片和视频
-            if not (mime.startswith("image/") or mime.startswith("video/")):
-                continue
-            try:
-                sha256 = await self._fetch_media_sha256(url)
-                if sha256:
-                    hashes.append(f"media:{sha256}")
-            except Exception:
-                pass  # 单个媒体下载失败不影响整体
-        return hashes
-
-    async def _fetch_media_sha256(self, url: str) -> str | None:
-        """下载媒体（限 5MB）并返回 SHA256，不阻塞整个流程"""
-        try:
-            session_lock = self._fetcher._session_lock
-            if session_lock is None:
-                return None
-            async with session_lock:
-                session = self._fetcher._session
-                if session is None or session.closed:
-                    return None
-            timeout = aiohttp.ClientTimeout(total=10, connect=5)
-            async with session.get(url, timeout=timeout) as resp:
-                if resp.status != 200:
-                    return None
-                chunk_size = 8192
-                limit = 5 * 1024 * 1024  # 5MB
-                sha = hashlib.sha256()
-                async for chunk in resp.content.iter_chunked(chunk_size):
-                    sha.update(chunk)
-                    if resp.content.total_bytes and resp.content.total_bytes > limit:
-                        return None  # 文件太大，忽略
-                    if sha.digest_size > limit:  # 简单大小保护
-                        return None
-                return sha.hexdigest()
-        except Exception:
-            return None
-
-    @staticmethod
-    def _upstream_material(entry: dict) -> str:
-        """构建上游兼容的身份材料"""
-        guid = str(entry.get("guid") or "").strip()
-        link = str(entry.get("link") or "").strip()
-        title = str(entry.get("title") or "").strip()
-        summary = str(entry.get("summary") or "").strip()
-
-        content_items = entry.get("content") or []
-        first_content_value = ""
-        if isinstance(content_items, list):
-            for content in content_items:
-                if isinstance(content, dict):
-                    value = content.get("value")
-                    if value:
-                        first_content_value = str(value).strip()
-                        break
-
-        return "\n".join([guid, link, title, summary, first_content_value])
-
-    @staticmethod
-    def _resolve_entry_link(entry: dict, feed_link: str | None = None) -> str:
-        """解析条目链接（清理追踪参数）"""
-        link = str(entry.get("link") or entry.get("guid") or "").strip()
-        if not link:
-            return ""
-        if feed_link and not link.startswith("http"):
-            from urllib.parse import urljoin
-
-            link = urljoin(feed_link, link)
-
-        # 清理追踪参数
-        try:
-            from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
-
-            parsed = urlparse(link)
-            if parsed.query:
-                # 过滤掉追踪参数
-                filtered_params = [
-                    (k, v)
-                    for k, v in parse_qsl(parsed.query)
-                    if k not in RSSScheduler.TRACKING_QUERY_PARAMS
-                ]
-                # 重建URL
-                link = urlunparse(
-                    (
-                        parsed.scheme,
-                        parsed.netloc,
-                        parsed.path,
-                        parsed.params,
-                        urlencode(filtered_params),
-                        parsed.fragment,
-                    )
-                )
-        except Exception:
-            pass  # 清理失败时保持原链接
-
-        return link
-
-    @staticmethod
-    def _legacy_crc32(entry: dict) -> str:
-        """遗留 v1 指纹（向后兼容）"""
-        hash_base = (
-            str(entry.get("link", ""))
-            + str(entry.get("title", ""))
-            + str(entry.get("published", ""))
-        )
-        return str(zlib.crc32(hash_base.encode()))
-
-    def _merge_hash_history(
-        self,
-        old_groups: list[list[str]],
-        new_groups: list[list[str]],
-        entry_count: int,
-    ) -> list[list[str]] | None:
-        """合并新旧哈希分组"""
-        history_limit = self._resolve_hash_history_limit(entry_count)
-
-        merged: list[list[str]] = []
-        seen_identity: set[str] = set()
-
-        for group in chain(new_groups, old_groups):
-            if not group:
-                continue
-            identity = next((h for h in group if h.startswith("sid:")), None)
-            if identity and identity in seen_identity:
-                continue
-            if identity:
-                seen_identity.add(identity)
-            merged.append(group)
-            if len(merged) >= history_limit:
-                break
-
-        return merged or None
-
-    def _resolve_hash_history_limit(self, entry_count: int) -> int:
-        """计算哈希历史限制"""
-        min_limit = self._hash_history_min
-        multiplier = self._hash_history_multiplier
-        hard_limit = self._hash_history_hard_limit
-        absolute_max = self.HASH_HISTORY_ABSOLUTE_MAX
-
-        min_limit = min(min_limit, absolute_max)
-        multiplier = min(multiplier, absolute_max)
-        hard_limit = min(hard_limit, absolute_max)
-        hard_limit = max(hard_limit, min_limit)
-
-        growth_limit = max(entry_count, 1) * multiplier
-        return min(max(min_limit, growth_limit), hard_limit)
+        if result.status == "not_modified":
+            self._stats.cached()
+        elif result.total_entries == 0:
+            self._stats.empty()
+        elif result.bootstrap_skipped:
+            self._stats.skipped()
+        elif result.new_entries > 0:
+            self._stats.updated()
+        else:
+            self._stats.not_updated()

--- a/src/infrastructure/translation/providers/base.py
+++ b/src/infrastructure/translation/providers/base.py
@@ -21,7 +21,7 @@ class BaseTranslator(ABC):
     NAME: str = ""
     LANG_MAP: dict[str, str] = {}
 
-    def __init__(self, session: "aiohttp.ClientSession | None" = None):
+    def __init__(self, session: aiohttp.ClientSession | None = None):
         self._session = session
 
     @abstractmethod

--- a/src/interfaces/__init__.py
+++ b/src/interfaces/__init__.py
@@ -1,5 +1,5 @@
 """接口层 - 提供 Web API 处理函数"""
 
-from .web_api import WebApiHandler, PLUGIN_NAME
+from .web_api import PLUGIN_NAME, WebApiHandler
 
 __all__ = ["WebApiHandler", "PLUGIN_NAME"]

--- a/src/interfaces/handlers/__init__.py
+++ b/src/interfaces/handlers/__init__.py
@@ -1,32 +1,27 @@
 """命令处理器模块（纯函数）"""
 
-from .subscription import (
-    handle_sub,
-    handle_unsub,
-    handle_sub_list,
-    handle_refresh,
-    handle_sub_state,
-)
-from .config import (
-    handle_sub_set,
-    handle_sub_set_user,
-    handle_sub_get_user,
-    handle_sub_set_session,
-    handle_sub_get_session,
-)
+from .admin import handle_admin_panel, handle_test_sub
 from .batch import (
     handle_batch_activate,
     handle_batch_deactivate,
-    handle_unsub_all,
     handle_batch_unsub,
+    handle_unsub_all,
 )
-from .data import (
-    handle_export,
-    handle_import,
+from .config import (
+    handle_sub_get_session,
+    handle_sub_get_user,
+    handle_sub_set,
+    handle_sub_set_session,
+    handle_sub_set_user,
 )
-from .admin import (
-    handle_test_sub,
-    handle_admin_panel,
+from .data import handle_export, handle_import
+from .subscription import (
+    handle_refresh,
+    handle_rss_stop,
+    handle_sub,
+    handle_sub_list,
+    handle_sub_state,
+    handle_unsub,
 )
 
 __all__ = [
@@ -34,6 +29,7 @@ __all__ = [
     "handle_unsub",
     "handle_sub_list",
     "handle_refresh",
+    "handle_rss_stop",
     "handle_sub_state",
     "handle_sub_set",
     "handle_sub_set_user",

--- a/src/interfaces/handlers/subscription.py
+++ b/src/interfaces/handlers/subscription.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from astrbot.api.event import AstrMessageEvent
 
+from ...application.services.session_push_queue import SessionPushQueue
+
 
 async def handle_sub(event: AstrMessageEvent, url: str, deps: dict) -> dict:
     """订阅 RSS 源"""
@@ -105,8 +107,20 @@ async def handle_refresh(event: AstrMessageEvent, feed_id: int, deps: dict) -> d
     """刷新订阅"""
     if feed_id <= 0:
         return {"plain": "请提供 Feed ID\n用法: /refresh <feed_id>"}
-    await deps["sync_service"].sync_feed(feed_id)
-    return {"plain": f"Feed {feed_id} 刷新完成"}
+    result = await deps["sync_service"].sync_feed(feed_id)
+    return {"plain": result.message}
+
+
+def handle_rss_stop(event: AstrMessageEvent, queue: SessionPushQueue) -> dict:
+    """停止当前会话正在运行的 RSS 推送任务"""
+    current_session = event.unified_msg_origin
+    result = queue.stop_current(current_session)
+    if result.stopped:
+        queued = (
+            f"，队列中还有 {result.queued_count} 个任务" if result.queued_count else ""
+        )
+        return {"plain": f"{result.message}{queued}"}
+    return {"plain": result.message}
 
 
 async def handle_sub_state(

--- a/src/interfaces/web_api.py
+++ b/src/interfaces/web_api.py
@@ -10,10 +10,11 @@ import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
-from quart import jsonify, request, Response
+from quart import Response, jsonify, request
 
 if TYPE_CHECKING:
     from astrbot.api.star import Context
+
     from ..application.commands.batch_activate_cmd import BatchActivateCommand
     from ..application.commands.batch_deactivate_cmd import BatchDeactivateCommand
     from ..application.commands.batch_unsubscribe_cmd import BatchUnsubscribeCommand
@@ -28,9 +29,9 @@ if TYPE_CHECKING:
     from ..application.commands.update_subscription_cmd import UpdateSubscriptionCommand
     from ..application.queries.get_feed_items_query import GetFeedItemsQuery
     from ..application.services import FeedSyncService
-    from ..infrastructure.config.config_manager import RsshubPluginConfig
     from ..domain.repositories.feed_repository import FeedRepository
     from ..domain.repositories.subscription_repository import SubscriptionRepository
+    from ..infrastructure.config.config_manager import RsshubPluginConfig
 
 PLUGIN_NAME = "astrbot_plugin_rsshub"
 
@@ -335,10 +336,22 @@ class WebApiHandler:
             return jsonify({"ok": False, "error": "feed_id 不能为空"})
 
         try:
-            await self._sync_service.sync_feed(int(feed_id))
+            result = await self._sync_service.sync_feed(int(feed_id))
             self._bump_counter()
             asyncio.create_task(self._broadcast({"event": "data_changed"}))
-            return jsonify({"ok": True, "message": f"Feed {feed_id} 刷新完成"})
+            return jsonify(
+                {
+                    "ok": result.success,
+                    "message": result.message,
+                    "status": result.status,
+                    "feed_id": result.feed_id,
+                    "total_entries": result.total_entries,
+                    "new_entries": result.new_entries,
+                    "dispatched": result.dispatched,
+                    "bootstrap_skipped": result.bootstrap_skipped,
+                    "error": result.error,
+                }
+            )
         except Exception as e:
             return jsonify({"ok": False, "error": str(e)})
 

--- a/tests/integration/test_plugin_integration.py
+++ b/tests/integration/test_plugin_integration.py
@@ -99,6 +99,7 @@ class TestCommandIntegration:
             "unsub_feed",
             "sub_list",
             "refresh_feed",
+            "stop_rss_job",
             "sub_state",
             "sub_set",
             "sub_set_user",

--- a/tests/unit/application/test_commands.py
+++ b/tests/unit/application/test_commands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -246,31 +245,30 @@ class TestRefreshFeedCommand:
         from astrbot_plugin_rsshub.src.application.commands.refresh_feed_cmd import (
             RefreshFeedCommand,
         )
+        from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+            FeedPollingResult,
+        )
         from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
 
         feed = Feed(
             id=1,
             link="https://example.com/rss.xml",
-            etag="",
+            title="Updated Feed",
         )
-
-        feed_repo = MagicMock()
-        feed_repo.get_by_id = AsyncMock(return_value=feed)
-        feed_repo.save = AsyncMock(return_value=feed)
-
-        fetcher = AsyncMock()
-        fetcher.fetch.return_value = MagicMock(
-            status=200,
-            etag="new-etag",
-            last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            rss_d=MagicMock(feed={"title": "Updated Feed"}, entries=sample_entries),
-            error=None,
+        polling_service = AsyncMock()
+        polling_service.poll_feed.return_value = FeedPollingResult(
+            success=True,
+            status="updated",
+            message="刷新完成 (ID: 1)，发现 2 个条目，新增 2 个",
+            feed_id=1,
+            total_entries=2,
+            new_entries=2,
+            feed=feed,
         )
-        fetcher.close = AsyncMock()
 
         cmd = RefreshFeedCommand(
-            feed_repo,
-            fetcher_factory=MagicMock(return_value=fetcher),
+            MagicMock(),
+            polling_service=polling_service,
         )
 
         result = await cmd.execute(feed_id=1)
@@ -278,8 +276,7 @@ class TestRefreshFeedCommand:
         assert result.success is True
         assert "发现 2 个条目" in result.message
         assert result.data.title == "Updated Feed"
-        feed_repo.save.assert_awaited_once_with(feed)
-        fetcher.close.assert_awaited_once()
+        polling_service.poll_feed.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
     async def test_refresh_no_update(self):
@@ -287,33 +284,34 @@ class TestRefreshFeedCommand:
         from astrbot_plugin_rsshub.src.application.commands.refresh_feed_cmd import (
             RefreshFeedCommand,
         )
+        from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+            FeedPollingResult,
+        )
         from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
 
         feed = Feed(
             id=1,
             link="https://example.com/rss.xml",
         )
-
-        feed_repo = MagicMock()
-        feed_repo.get_by_id = AsyncMock(return_value=feed)
-
-        fetcher = AsyncMock()
-        fetcher.fetch.return_value = MagicMock(
-            status=304,  # Not Modified
-            error=None,
+        polling_service = AsyncMock()
+        polling_service.poll_feed.return_value = FeedPollingResult(
+            success=True,
+            status="not_modified",
+            message="Feed 未修改，无需更新 (ID: 1)",
+            feed_id=1,
+            feed=feed,
         )
-        fetcher.close = AsyncMock()
 
         cmd = RefreshFeedCommand(
-            feed_repo,
-            fetcher_factory=MagicMock(return_value=fetcher),
+            MagicMock(),
+            polling_service=polling_service,
         )
 
         result = await cmd.execute(feed_id=1)
 
         assert result.success is True
         assert "未修改" in result.message
-        fetcher.close.assert_awaited_once()
+        polling_service.poll_feed.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
     async def test_refresh_fetch_error(self):
@@ -321,28 +319,125 @@ class TestRefreshFeedCommand:
         from astrbot_plugin_rsshub.src.application.commands.refresh_feed_cmd import (
             RefreshFeedCommand,
         )
-        from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
-        from astrbot_plugin_rsshub.src.domain.exceptions import WebError
-
-        feed = Feed(id=1, link="https://example.com/rss.xml")
-
-        feed_repo = MagicMock()
-        feed_repo.get_by_id = AsyncMock(return_value=feed)
-
-        fetcher = AsyncMock()
-        fetcher.fetch.return_value = MagicMock(
-            status=0,
-            error=WebError(error_name="Connection timeout", url=feed.link),
+        from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+            FeedPollingResult,
         )
-        fetcher.close = AsyncMock()
+
+        polling_service = AsyncMock()
+        polling_service.poll_feed.return_value = FeedPollingResult(
+            success=False,
+            status="fetch_error",
+            message="抓取失败: Connection timeout",
+            feed_id=1,
+            error="Connection timeout",
+        )
 
         cmd = RefreshFeedCommand(
-            feed_repo,
-            fetcher_factory=MagicMock(return_value=fetcher),
+            MagicMock(),
+            polling_service=polling_service,
         )
 
         result = await cmd.execute(feed_id=1)
 
         assert result.success is False
         assert "Connection timeout" in result.message
-        fetcher.close.assert_awaited_once()
+        polling_service.poll_feed.assert_awaited_once_with(1)
+
+
+class TestTestSubscriptionCommand:
+    """测试订阅测试命令"""
+
+    @pytest.mark.asyncio
+    async def test_test_subscription_uses_polling_service_read_path(self):
+        from astrbot_plugin_rsshub.src.application.commands.test_subscription_cmd import (
+            TestSubscriptionCommand,
+        )
+        from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+            FeedReadResult,
+        )
+        from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
+        from astrbot_plugin_rsshub.src.domain.entities.subscription import Subscription
+        from astrbot_plugin_rsshub.src.infrastructure.fetcher.rss.parser import (
+            EntryParsed,
+        )
+
+        subscription = Subscription(id=5, user_id="user123", feed_id=1)
+        feed = Feed(id=1, link="https://example.com/rss.xml", title="Example")
+        entry = EntryParsed(
+            guid="guid-1",
+            title="Entry",
+            link="https://example.com/entry",
+            summary="Summary",
+        )
+        web_feed = MagicMock(rss_d=MagicMock(feed={"title": "Example"}))
+
+        sub_repo = MagicMock()
+        sub_repo.get_by_id = AsyncMock(return_value=subscription)
+        feed_repo = MagicMock()
+        feed_repo.get_by_id = AsyncMock(return_value=feed)
+        polling_service = AsyncMock()
+        polling_service.fetch_feed_entries.return_value = FeedReadResult(
+            success=True,
+            status="fetched",
+            message="ok",
+            entries=[entry],
+            web_feed=web_feed,
+        )
+
+        cmd = TestSubscriptionCommand(
+            subscription_repo=sub_repo,
+            feed_repo=feed_repo,
+            polling_service=polling_service,
+        )
+
+        result = await cmd.execute(sub_id=5, user_id="user123")
+
+        assert result.success is True
+        assert result.data["test_result"].entry_count == 1
+        polling_service.fetch_feed_entries.assert_awaited_once_with(
+            "https://example.com/rss.xml",
+            verbose=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_test_url_uses_polling_service_read_path(self):
+        from astrbot_plugin_rsshub.src.application.commands.test_subscription_cmd import (
+            TestSubscriptionCommand,
+        )
+        from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+            FeedReadResult,
+        )
+        from astrbot_plugin_rsshub.src.infrastructure.fetcher.rss.parser import (
+            EntryParsed,
+        )
+
+        entry = EntryParsed(
+            guid="guid-1",
+            title="Entry",
+            link="https://example.com/entry",
+            summary="Summary",
+        )
+        web_feed = MagicMock(rss_d=MagicMock(feed={"title": "Example"}))
+        polling_service = AsyncMock()
+        polling_service.fetch_feed_entries.return_value = FeedReadResult(
+            success=True,
+            status="fetched",
+            message="ok",
+            entries=[entry],
+            web_feed=web_feed,
+        )
+
+        cmd = TestSubscriptionCommand(
+            subscription_repo=MagicMock(),
+            feed_repo=MagicMock(),
+            polling_service=polling_service,
+        )
+
+        result = await cmd.execute_by_url("https://example.com/rss.xml")
+
+        assert result.success is True
+        assert result.data["test_result"].feed_info.title == "Example"
+        polling_service.fetch_feed_entries.assert_awaited_once_with(
+            "https://example.com/rss.xml",
+            verbose=True,
+        )

--- a/tests/unit/application/test_feed_polling_service.py
+++ b/tests/unit/application/test_feed_polling_service.py
@@ -427,16 +427,16 @@ def test_tracking_query_params_stripped_for_hash_and_dispatch_link():
     )
 
     assert (
-        service._strip_tracking_params(entry.link)
-        == "https://example.com/post?foo=bar"
+        service._strip_tracking_params(entry.link) == "https://example.com/post?foo=bar"
     )
     assert service._resolve_entry_link(entry) == "https://example.com/post?foo=bar"
     assert service._resolve_entry_link(entry_with_other_tracking) == (
         "https://example.com/post?foo=bar"
     )
-    assert service._hash_entry(entry)[0] == service._hash_entry(
-        entry_with_other_tracking
-    )[0]
+    assert (
+        service._hash_entry(entry)[0]
+        == service._hash_entry(entry_with_other_tracking)[0]
+    )
 
 
 def test_build_conditional_headers_from_feed_etag_and_last_modified():

--- a/tests/unit/application/test_feed_polling_service.py
+++ b/tests/unit/application/test_feed_polling_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -123,6 +124,63 @@ async def test_poll_feed_parse_error_is_reported():
     assert result.success is False
     assert result.status == "parse_error"
     assert "bad xml" in result.message
+    feed_repo.save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_fetch_exception_is_reported():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock()
+
+    fetcher = AsyncMock()
+    fetcher.fetch.side_effect = RuntimeError("network boom")
+    fetcher.close = AsyncMock()
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=MagicMock(),
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is False
+    assert result.status == "fetch_error"
+    assert "network boom" in result.message
+    assert result.error == "network boom"
+    feed_repo.save.assert_not_called()
+    fetcher.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_empty_content_is_reported_without_parsing():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock()
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed(status=200, content=None)
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is False
+    assert result.status == "empty_content"
+    assert "RSS 内容为空" in result.message
+    parser.parse.assert_not_called()
     feed_repo.save.assert_not_called()
 
 
@@ -348,3 +406,53 @@ async def test_poll_feed_accepts_legacy_flat_hash_history():
     assert result.new_entries == 0
     assert feed.entry_hashes
     assert legacy_hash in feed.entry_hashes[0]
+
+
+def test_tracking_query_params_stripped_for_hash_and_dispatch_link():
+    entry = EntryParsed(
+        guid="",
+        title="Tracked entry",
+        link="https://example.com/post?utm_source=newsletter&foo=bar",
+    )
+    entry_with_other_tracking = EntryParsed(
+        guid="",
+        title="Tracked entry",
+        link="https://example.com/post?utm_source=other&foo=bar",
+    )
+
+    service = FeedPollingService(
+        feed_repo=MagicMock(),
+        subscription_repo=MagicMock(),
+        rss_settings=RSSSettings(tracking_query_params=("utm_source",)),
+    )
+
+    assert (
+        service._strip_tracking_params(entry.link)
+        == "https://example.com/post?foo=bar"
+    )
+    assert service._resolve_entry_link(entry) == "https://example.com/post?foo=bar"
+    assert service._resolve_entry_link(entry_with_other_tracking) == (
+        "https://example.com/post?foo=bar"
+    )
+    assert service._hash_entry(entry)[0] == service._hash_entry(
+        entry_with_other_tracking
+    )[0]
+
+
+def test_build_conditional_headers_from_feed_etag_and_last_modified():
+    last_modified = datetime(2015, 10, 21, 7, 28, tzinfo=timezone.utc)
+    feed = Feed(
+        id=1,
+        link="https://example.com/feed",
+        etag='"abcdef"',
+        last_modified=last_modified,
+    )
+    service = FeedPollingService(
+        feed_repo=MagicMock(),
+        subscription_repo=MagicMock(),
+    )
+
+    headers = service._build_conditional_headers(feed)
+
+    assert headers["If-None-Match"] == '"abcdef"'
+    assert headers["If-Modified-Since"] == format_datetime(last_modified)

--- a/tests/unit/application/test_feed_polling_service.py
+++ b/tests/unit/application/test_feed_polling_service.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+    FeedPollingService,
+)
+from astrbot_plugin_rsshub.src.application.settings import RSSSettings
+from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
+from astrbot_plugin_rsshub.src.infrastructure.fetcher.rss.parser import EntryParsed
+
+
+def _web_feed(**kwargs):
+    data = {
+        "status": 200,
+        "error": None,
+        "content": b"<rss />",
+        "etag": None,
+        "last_modified": None,
+        "rss_d": MagicMock(feed={}),
+    }
+    data.update(kwargs)
+    return MagicMock(**data)
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_records_new_entries_and_metadata():
+    feed = Feed(id=1, link="https://example.com/rss.xml", title="Old")
+    entries = [
+        EntryParsed(guid="guid-1", title="One", link="https://example.com/1"),
+        EntryParsed(guid="guid-2", title="Two", link="https://example.com/2"),
+    ]
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+    sub_repo = MagicMock()
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed(
+        rss_d=MagicMock(feed={"title": "New Title"}),
+        etag="etag-1",
+        last_modified=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = (entries, None)
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=sub_repo,
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is True
+    assert result.status == "updated"
+    assert result.total_entries == 2
+    assert result.new_entries == 2
+    assert result.feed.title == "New Title"
+    assert result.feed.etag == "etag-1"
+    assert result.feed.entry_hashes is not None
+    assert len(result.feed.entry_hashes) == 2
+    assert result.feed.entry_hashes[0][0].startswith("sid:")
+    assert "guid-1" in result.feed.entry_hashes[0]
+    assert "guid-2" in result.feed.entry_hashes[1]
+    feed_repo.save.assert_awaited_once_with(feed)
+    fetcher.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_not_modified_does_not_save():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock()
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed(status=304, content=None)
+    fetcher.close = AsyncMock()
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=MagicMock(),
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is True
+    assert result.status == "not_modified"
+    feed_repo.save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_parse_error_is_reported():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock()
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = ([], "bad xml")
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is False
+    assert result.status == "parse_error"
+    assert "bad xml" in result.message
+    feed_repo.save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_dispatches_new_entries_when_enabled():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    entry = EntryParsed(
+        guid="guid-1",
+        title="One",
+        link="https://example.com/1",
+        summary="Summary",
+    )
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = ([entry], None)
+
+    dispatcher = AsyncMock()
+    dispatcher.dispatch_to_feed_subscribers.return_value = {
+        "success": 1,
+        "failed": 0,
+        "pending": 0,
+    }
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+        notification_dispatcher=dispatcher,
+        rss_settings=RSSSettings(bootstrap_skip_history=False),
+    )
+
+    result = await service.poll_feed(1, notify_new_entries=True)
+
+    assert result.success is True
+    assert result.dispatched == 1
+    dispatcher.dispatch_to_feed_subscribers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_group_limits_dispatch_to_selected_subscriptions():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    entries = [
+        EntryParsed(guid="guid-1", title="One", link="https://example.com/1"),
+        EntryParsed(guid="guid-2", title="Two", link="https://example.com/2"),
+    ]
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = (entries, None)
+
+    dispatcher = AsyncMock()
+    dispatcher.dispatch_to_feed_subscribers.return_value = {
+        "success": 1,
+        "failed": 0,
+        "pending": 0,
+    }
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+        notification_dispatcher=dispatcher,
+        rss_settings=RSSSettings(bootstrap_skip_history=False),
+        history_entry_limit=1,
+    )
+
+    result = await service.poll_feed_group(1, [10, 20, 10])
+
+    assert result.success is True
+    assert result.dispatched == 1
+    dispatcher.dispatch_to_feed_subscribers.assert_awaited_once()
+    call_kwargs = dispatcher.dispatch_to_feed_subscribers.await_args.kwargs
+    assert call_kwargs["subscription_ids"] == [10, 20]
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_bootstrap_records_history_without_dispatching():
+    feed = Feed(id=1, link="https://example.com/rss.xml")
+    entry = EntryParsed(
+        guid="guid-1",
+        title="One",
+        link="https://example.com/1",
+        summary="Summary",
+    )
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = ([entry], None)
+    dispatcher = AsyncMock()
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+        notification_dispatcher=dispatcher,
+        rss_settings=RSSSettings(bootstrap_skip_history=True),
+    )
+
+    result = await service.poll_feed(1, notify_new_entries=True)
+
+    assert result.success is True
+    assert result.status == "bootstrapped"
+    assert result.new_entries == 1
+    assert result.dispatched == 0
+    assert result.bootstrap_skipped is True
+    assert feed.entry_hashes
+    assert feed.entry_hashes[0][0].startswith("sid:")
+    dispatcher.dispatch_to_feed_subscribers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_uses_stable_identity_when_content_changes():
+    seed_entry = EntryParsed(
+        guid="guid-1",
+        title="Original",
+        link="https://example.com/1?utm_source=test",
+        summary="Original summary",
+    )
+    changed_entry = EntryParsed(
+        guid="guid-1",
+        title="Updated title",
+        link="https://example.com/1",
+        summary="Changed summary with timestamp",
+    )
+
+    seed_service = FeedPollingService(
+        feed_repo=MagicMock(),
+        subscription_repo=MagicMock(),
+    )
+    existing_hashes = [seed_service._hash_entry(seed_entry, "https://example.com/rss")]
+
+    feed = Feed(
+        id=1,
+        link="https://example.com/rss.xml",
+        entry_hashes=existing_hashes,
+    )
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = ([changed_entry], None)
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is True
+    assert result.status == "no_new_entries"
+    assert result.new_entries == 0
+    assert len(feed.entry_hashes or []) == 1
+
+
+@pytest.mark.asyncio
+async def test_poll_feed_accepts_legacy_flat_hash_history():
+    entry = EntryParsed(
+        guid="",
+        title="Legacy",
+        link="https://example.com/legacy",
+    )
+    service_for_hash = FeedPollingService(
+        feed_repo=MagicMock(),
+        subscription_repo=MagicMock(),
+    )
+    legacy_hash = service_for_hash._legacy_crc32(entry)
+    feed = Feed(
+        id=1,
+        link="https://example.com/rss.xml",
+        entry_hashes=[legacy_hash],
+    )
+    feed_repo = MagicMock()
+    feed_repo.get_by_id = AsyncMock(return_value=feed)
+    feed_repo.save = AsyncMock(side_effect=lambda value: value)
+
+    fetcher = AsyncMock()
+    fetcher.fetch.return_value = _web_feed()
+    fetcher.close = AsyncMock()
+
+    parser = MagicMock()
+    parser.parse.return_value = ([entry], None)
+
+    service = FeedPollingService(
+        feed_repo=feed_repo,
+        subscription_repo=MagicMock(),
+        fetcher_factory=MagicMock(return_value=fetcher),
+        parser=parser,
+    )
+
+    result = await service.poll_feed(1)
+
+    assert result.success is True
+    assert result.new_entries == 0
+    assert feed.entry_hashes
+    assert legacy_hash in feed.entry_hashes[0]

--- a/tests/unit/application/test_notification_dispatcher.py
+++ b/tests/unit/application/test_notification_dispatcher.py
@@ -8,6 +8,7 @@ from astrbot_plugin_rsshub.src.application.services.notification_dispatcher impo
     NotificationDispatcher,
 )
 from astrbot_plugin_rsshub.src.application.services.session_push_queue import (
+    PushJobResult,
     SessionPushQueue,
 )
 from astrbot_plugin_rsshub.src.domain.entities.push_history import PushHistory
@@ -208,3 +209,100 @@ async def test_dispatch_uses_session_queue_for_same_session():
     assert stats == {"success": 2, "failed": 0, "pending": 0}
     assert len(sender.requests) == 2
     assert queue.get_current_job("telegram:Group:1") is None
+
+
+@pytest.mark.asyncio
+async def test_send_to_session_returns_cancelled_result_from_queue():
+    sender = FakeSender()
+    sub = Subscription(
+        id=1,
+        user_id="user-1",
+        feed_id=10,
+        platform_name="telegram",
+        target_session="telegram:Group:1",
+    )
+    queue = SessionPushQueue()
+    queue.enqueue = AsyncMock(
+        return_value=PushJobResult(
+            job_id="rss-000123",
+            session_id="telegram:Group:1",
+            ok=False,
+            cancelled=True,
+            error="job cancelled",
+        )
+    )
+
+    dispatcher = NotificationDispatcher(
+        subscription_repo=AsyncMock(),
+        push_history_repo=AsyncMock(),
+        sender_provider=FakeSenderProvider(sender),
+        push_job_queue=queue,
+    )
+
+    result = await dispatcher.send_to_session(
+        subscription=sub,
+        content="content",
+        media_urls=None,
+    )
+
+    assert result["ok"] is False
+    assert result["cancelled"] is True
+    assert result["job_id"] == "rss-000123"
+    assert "Cancelled by /rss_stop" in result["error"]
+    assert sender.requests == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pending_retries_marks_cancelled_history_failed():
+    sender = FakeSender()
+    sub = Subscription(
+        id=1,
+        user_id="user-1",
+        feed_id=10,
+        platform_name="telegram",
+        target_session="telegram:Group:1",
+    )
+    history = PushHistory(
+        id=99,
+        sub_id=1,
+        user_id="user-1",
+        feed_id=10,
+        content="content",
+        entry_title="title",
+        entry_link="https://example.com/entry",
+        status="retrying",
+        retry_count=1,
+        max_retries=3,
+    )
+
+    sub_repo = AsyncMock()
+    sub_repo.get_by_id.return_value = sub
+    history_repo = AsyncMock()
+    history_repo.get_and_mark_retrying.return_value = [history]
+    history_repo.save.side_effect = lambda value: value
+
+    queue = SessionPushQueue()
+    queue.enqueue = AsyncMock(
+        return_value=PushJobResult(
+            job_id="rss-000456",
+            session_id="telegram:Group:1",
+            ok=False,
+            cancelled=True,
+            error="job cancelled",
+        )
+    )
+
+    dispatcher = NotificationDispatcher(
+        subscription_repo=sub_repo,
+        push_history_repo=history_repo,
+        sender_provider=FakeSenderProvider(sender),
+        push_job_queue=queue,
+    )
+
+    stats = await dispatcher.dispatch_pending_retries(limit=10)
+
+    assert stats == {"success": 0, "failed": 1, "skipped": 0}
+    assert history.status == "failed"
+    assert history.max_retries == 0
+    assert "Cancelled by /rss_stop" in (history.fail_reason or "")
+    history_repo.save.assert_awaited_once_with(history)

--- a/tests/unit/application/test_notification_dispatcher.py
+++ b/tests/unit/application/test_notification_dispatcher.py
@@ -7,6 +7,9 @@ from astrbot_plugin_rsshub.src.application.ports import SendResult
 from astrbot_plugin_rsshub.src.application.services.notification_dispatcher import (
     NotificationDispatcher,
 )
+from astrbot_plugin_rsshub.src.application.services.session_push_queue import (
+    SessionPushQueue,
+)
 from astrbot_plugin_rsshub.src.domain.entities.push_history import PushHistory
 from astrbot_plugin_rsshub.src.domain.entities.subscription import Subscription
 
@@ -112,3 +115,96 @@ async def test_dispatch_guard_skips_already_successful_entry_guid():
     assert stats == {"success": 0, "failed": 0, "pending": 0}
     assert sender.requests == []
     history_repo.save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_can_limit_to_selected_subscription_ids():
+    sender = FakeSender()
+    subs = [
+        Subscription(
+            id=1,
+            user_id="user-1",
+            feed_id=10,
+            platform_name="telegram",
+            target_session="telegram:Group:1",
+        ),
+        Subscription(
+            id=2,
+            user_id="user-2",
+            feed_id=10,
+            platform_name="telegram",
+            target_session="telegram:Group:2",
+        ),
+    ]
+
+    sub_repo = AsyncMock()
+    sub_repo.get_active_by_feed_id.return_value = subs
+    history_repo = AsyncMock()
+    history_repo.get_by_sub.return_value = []
+    history_repo.save.side_effect = lambda history: history
+
+    dispatcher = NotificationDispatcher(
+        subscription_repo=sub_repo,
+        push_history_repo=history_repo,
+        sender_provider=FakeSenderProvider(sender),
+    )
+
+    stats = await dispatcher.dispatch_to_feed_subscribers(
+        feed_id=10,
+        content="content",
+        entry_title="title",
+        entry_link="https://example.com/entry",
+        entry_guid="guid-1",
+        subscription_ids=[2],
+    )
+
+    assert stats == {"success": 1, "failed": 0, "pending": 0}
+    assert len(sender.requests) == 1
+    assert sender.requests[0][0].session_id == "telegram:Group:2"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_session_queue_for_same_session():
+    sender = FakeSender()
+    queue = SessionPushQueue()
+    subs = [
+        Subscription(
+            id=1,
+            user_id="user-1",
+            feed_id=10,
+            platform_name="telegram",
+            target_session="telegram:Group:1",
+        ),
+        Subscription(
+            id=2,
+            user_id="user-2",
+            feed_id=10,
+            platform_name="telegram",
+            target_session="telegram:Group:1",
+        ),
+    ]
+
+    sub_repo = AsyncMock()
+    sub_repo.get_active_by_feed_id.return_value = subs
+    history_repo = AsyncMock()
+    history_repo.get_by_sub.return_value = []
+    history_repo.save.side_effect = lambda history: history
+
+    dispatcher = NotificationDispatcher(
+        subscription_repo=sub_repo,
+        push_history_repo=history_repo,
+        sender_provider=FakeSenderProvider(sender),
+        push_job_queue=queue,
+    )
+
+    stats = await dispatcher.dispatch_to_feed_subscribers(
+        feed_id=10,
+        content="content",
+        entry_title="title",
+        entry_link="https://example.com/entry",
+        entry_guid="guid-1",
+    )
+
+    assert stats == {"success": 2, "failed": 0, "pending": 0}
+    assert len(sender.requests) == 2
+    assert queue.get_current_job("telegram:Group:1") is None

--- a/tests/unit/application/test_session_push_queue.py
+++ b/tests/unit/application/test_session_push_queue.py
@@ -46,6 +46,7 @@ async def test_same_session_jobs_run_serially():
         "start:rss-000002",
         "end:rss-000002",
     ]
+    assert queue._states == {}
 
 
 @pytest.mark.asyncio
@@ -102,3 +103,40 @@ async def test_stop_current_cancels_running_job_and_releases_next_job():
     assert second_result.ok is True
     assert second_result.value == "next"
     assert next_ran.is_set()
+    assert queue._states == {}
+
+
+def test_stop_current_without_running_job_reports_noop():
+    queue = SessionPushQueue()
+
+    result = queue.stop_current("unknown-session")
+
+    assert result.stopped is False
+    assert result.session_id == "unknown-session"
+    assert "没有正在运行" in result.message
+    assert queue._states == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_all_cancels_running_jobs_across_sessions():
+    queue = SessionPushQueue()
+    started: set[str] = set()
+    all_started = asyncio.Event()
+
+    async def long_running(job):
+        started.add(job.session_id)
+        if started == {"session-1", "session-2"}:
+            all_started.set()
+        await asyncio.sleep(60)
+        return "never"
+
+    first_task = asyncio.create_task(queue.enqueue("session-1", long_running))
+    second_task = asyncio.create_task(queue.enqueue("session-2", long_running))
+    await all_started.wait()
+
+    await queue.stop_all()
+    first_result, second_result = await asyncio.gather(first_task, second_task)
+
+    assert first_result.cancelled is True
+    assert second_result.cancelled is True
+    assert queue._states == {}

--- a/tests/unit/application/test_session_push_queue.py
+++ b/tests/unit/application/test_session_push_queue.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from astrbot_plugin_rsshub.src.application.services.session_push_queue import (
+    SessionPushQueue,
+)
+
+
+@pytest.mark.asyncio
+async def test_same_session_jobs_run_serially():
+    queue = SessionPushQueue()
+    events: list[str] = []
+    release_first = asyncio.Event()
+
+    async def first(job):
+        events.append(f"start:{job.job_id}")
+        await release_first.wait()
+        events.append(f"end:{job.job_id}")
+        return "first"
+
+    async def second(job):
+        events.append(f"start:{job.job_id}")
+        events.append(f"end:{job.job_id}")
+        return "second"
+
+    first_task = asyncio.create_task(queue.enqueue("session-1", first))
+    await asyncio.sleep(0)
+    second_task = asyncio.create_task(queue.enqueue("session-1", second))
+    await asyncio.sleep(0)
+
+    assert queue.get_queued_count("session-1") == 1
+    assert events == ["start:rss-000001"]
+
+    release_first.set()
+    first_result, second_result = await asyncio.gather(first_task, second_task)
+
+    assert first_result.ok is True
+    assert first_result.value == "first"
+    assert second_result.ok is True
+    assert second_result.value == "second"
+    assert events == [
+        "start:rss-000001",
+        "end:rss-000001",
+        "start:rss-000002",
+        "end:rss-000002",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_different_sessions_can_run_concurrently():
+    queue = SessionPushQueue()
+    both_started = asyncio.Event()
+    started: set[str] = set()
+
+    async def work(job):
+        started.add(job.session_id)
+        if started == {"session-1", "session-2"}:
+            both_started.set()
+        await both_started.wait()
+        return job.session_id
+
+    results = await asyncio.gather(
+        queue.enqueue("session-1", work),
+        queue.enqueue("session-2", work),
+    )
+
+    assert {result.value for result in results} == {"session-1", "session-2"}
+
+
+@pytest.mark.asyncio
+async def test_stop_current_cancels_running_job_and_releases_next_job():
+    queue = SessionPushQueue()
+    started = asyncio.Event()
+    next_ran = asyncio.Event()
+
+    async def long_running(_job):
+        started.set()
+        await asyncio.sleep(60)
+        return "never"
+
+    async def next_job(_job):
+        next_ran.set()
+        return "next"
+
+    first_task = asyncio.create_task(queue.enqueue("session-1", long_running))
+    await started.wait()
+    second_task = asyncio.create_task(queue.enqueue("session-1", next_job))
+    await asyncio.sleep(0)
+
+    stop_result = queue.stop_current("session-1")
+
+    assert stop_result.stopped is True
+    assert stop_result.job_id == "rss-000001"
+    assert stop_result.queued_count == 1
+
+    first_result = await first_task
+    second_result = await second_task
+
+    assert first_result.cancelled is True
+    assert second_result.ok is True
+    assert second_result.value == "next"
+    assert next_ran.is_set()

--- a/tests/unit/infrastructure/test_rss_scheduler.py
+++ b/tests/unit/infrastructure/test_rss_scheduler.py
@@ -158,3 +158,23 @@ async def test_scheduler_still_updates_next_check_after_polling_error(monkeypatc
     )
     assert subs[0].next_check_time is not None
     assert subs[0].next_check_time > before
+
+
+@pytest.mark.asyncio
+async def test_scheduler_does_not_poll_when_no_subscriptions_are_due(monkeypatch):
+    fake_db = _FakeDatabase([])
+    monkeypatch.setattr(
+        "astrbot_plugin_rsshub.src.infrastructure.schedule.rss_scheduler.get_database",
+        lambda: fake_db,
+    )
+
+    polling_service = AsyncMock()
+
+    scheduler = RSSScheduler(
+        feed_polling_service=polling_service,
+        default_interval=10,
+    )
+
+    await scheduler.run_periodic_task()
+
+    polling_service.poll_feed_group.assert_not_awaited()

--- a/tests/unit/infrastructure/test_rss_scheduler.py
+++ b/tests/unit/infrastructure/test_rss_scheduler.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from astrbot_plugin_rsshub.src.application.services.feed_polling_service import (
+    FeedPollingResult,
+)
+from astrbot_plugin_rsshub.src.infrastructure.persistence.models import SubORM
+from astrbot_plugin_rsshub.src.infrastructure.schedule.rss_scheduler import RSSScheduler
+
+
+class _ScalarResult:
+    def __init__(self, values):
+        self._values = values
+
+    def all(self):
+        return self._values
+
+
+class _ExecuteResult:
+    def __init__(self, values):
+        self._values = values
+
+    def scalars(self):
+        return _ScalarResult(self._values)
+
+
+class _FakeSession:
+    def __init__(self, subs: list[SubORM]):
+        self._subs = subs
+        self._by_id = {sub.id: sub for sub in subs}
+        self.commits = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    async def execute(self, _stmt):
+        return _ExecuteResult(self._subs)
+
+    async def get(self, _model, item_id):
+        return self._by_id.get(item_id)
+
+    def add(self, _item):
+        return None
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeDatabase:
+    def __init__(self, subs: list[SubORM]):
+        self.subs = subs
+        self.sessions: list[_FakeSession] = []
+
+    def get_session(self):
+        session = _FakeSession(self.subs)
+        self.sessions.append(session)
+        return session
+
+
+def _sub(sub_id: int, feed_id: int, interval: int | None) -> SubORM:
+    return SubORM(
+        id=sub_id,
+        state=1,
+        user_id=f"user-{sub_id}",
+        feed_id=feed_id,
+        title="",
+        interval=interval,
+        next_check_time=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_groups_due_subscriptions_by_feed_and_triggers_polling(
+    monkeypatch,
+):
+    subs = [_sub(1, 10, 5), _sub(2, 10, 15), _sub(3, 20, None)]
+    fake_db = _FakeDatabase(subs)
+    monkeypatch.setattr(
+        "astrbot_plugin_rsshub.src.infrastructure.schedule.rss_scheduler.get_database",
+        lambda: fake_db,
+    )
+
+    polling_service = AsyncMock()
+    polling_service.poll_feed_group.return_value = FeedPollingResult(
+        success=True,
+        status="updated",
+        message="ok",
+        feed_id=10,
+        total_entries=2,
+        new_entries=1,
+    )
+    dispatcher = AsyncMock()
+    dispatcher.dispatch_pending_retries.return_value = {
+        "success": 0,
+        "failed": 0,
+        "skipped": 0,
+    }
+
+    scheduler = RSSScheduler(
+        feed_polling_service=polling_service,
+        notification_dispatcher=dispatcher,
+        default_interval=10,
+    )
+    await scheduler.run_periodic_task()
+
+    calls = polling_service.poll_feed_group.await_args_list
+    assert len(calls) == 2
+    assert calls[0].args == (10, [1, 2])
+    assert calls[0].kwargs == {"notify_new_entries": True}
+    assert calls[1].args == (20, [3])
+    assert calls[1].kwargs == {"notify_new_entries": True}
+
+    assert subs[0].next_check_time is not None
+    assert subs[1].next_check_time is not None
+    assert subs[2].next_check_time is not None
+    assert 590 <= (subs[1].next_check_time - subs[0].next_check_time).total_seconds() <= 610
+    assert 290 <= (subs[2].next_check_time - subs[0].next_check_time).total_seconds() <= 310
+
+
+@pytest.mark.asyncio
+async def test_scheduler_still_updates_next_check_after_polling_error(monkeypatch):
+    subs = [_sub(1, 10, 5)]
+    fake_db = _FakeDatabase(subs)
+    monkeypatch.setattr(
+        "astrbot_plugin_rsshub.src.infrastructure.schedule.rss_scheduler.get_database",
+        lambda: fake_db,
+    )
+
+    polling_service = AsyncMock()
+    polling_service.poll_feed_group.side_effect = RuntimeError("boom")
+
+    scheduler = RSSScheduler(
+        feed_polling_service=polling_service,
+        default_interval=10,
+    )
+    before = datetime.now(timezone.utc)
+
+    await scheduler.run_periodic_task()
+
+    polling_service.poll_feed_group.assert_awaited_once_with(
+        10,
+        [1],
+        notify_new_entries=True,
+    )
+    assert subs[0].next_check_time is not None
+    assert subs[0].next_check_time > before

--- a/tests/unit/infrastructure/test_rss_scheduler.py
+++ b/tests/unit/infrastructure/test_rss_scheduler.py
@@ -119,8 +119,16 @@ async def test_scheduler_groups_due_subscriptions_by_feed_and_triggers_polling(
     assert subs[0].next_check_time is not None
     assert subs[1].next_check_time is not None
     assert subs[2].next_check_time is not None
-    assert 590 <= (subs[1].next_check_time - subs[0].next_check_time).total_seconds() <= 610
-    assert 290 <= (subs[2].next_check_time - subs[0].next_check_time).total_seconds() <= 310
+    assert (
+        590
+        <= (subs[1].next_check_time - subs[0].next_check_time).total_seconds()
+        <= 610
+    )
+    assert (
+        290
+        <= (subs[2].next_check_time - subs[0].next_check_time).total_seconds()
+        <= 310
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- unify manual refresh, Web API refresh, test subscription, and scheduler polling through FeedPollingService
- downgrade RSSScheduler to a timing adapter that only loads due subscriptions, groups by feed, triggers polling, and updates next_check_time
- add scoped dispatch, session push queue handling, media fingerprint port/adapter, and focused scheduler/polling tests
- update PLAN.md to mark phases 3 and 4 complete

## Tests
- PYTEST_ADDOPTS='-o cache_dir=.pytest_cache' pytest tests/unit/application tests/unit/infrastructure/test_rss_scheduler.py tests/integration/test_plugin_integration.py -q
- UV_CACHE_DIR=.uv-cache RUFF_CACHE_DIR=.ruff_cache uv run ruff check src/application/services/feed_polling_service.py src/application/services/notification_dispatcher.py src/application/commands/test_subscription_cmd.py src/infrastructure/schedule/rss_scheduler.py src/infrastructure/media/fingerprint_service.py tests/unit/application/test_commands.py tests/unit/application/test_feed_polling_service.py tests/unit/application/test_notification_dispatcher.py tests/unit/infrastructure/test_rss_scheduler.py main.py PLAN.md src/interfaces/handlers/subscription.py

## Summary by Sourcery

通过新的 FeedPollingService 统一所有订阅源轮询路径，并将 RSS 调度器简化为一个定时适配器，把轮询和通知委托给应用服务。

New Features:
- 引入 FeedPollingService 作为统一的应用层订阅源轮询用例，供手动刷新、Web API 刷新、订阅测试和调度器使用。
- 添加会话作用域的推送任务队列以及 `/rss_stop` 命令，用于串行化会话级推送投递，并允许取消进行中的 RSS 推送任务。
- 添加媒体指纹端口和基于 HTTP 的适配器，用于计算媒体内容哈希，以支持未来的去重和处理。

Enhancements:
- 重构 RSSScheduler，使其只负责处理到期订阅的选择、按订阅源分组、触发 FeedPollingService，以及更新 `next_check_time`，同时将重试和历史清理委托给 NotificationDispatcher。
- 扩展 NotificationDispatcher，使其支持会话作用域的推送排队、支持感知取消的重试处理，以及可选地限制到特定订阅 ID。
- 更新刷新和测试订阅命令、Web API 以及 FeedSyncService，使其消费 FeedPollingService 的结果，而不是直接调用基础设施层的抓取器和解析器。
- 规范化 `Feed.entry_hashes`，通过模型校验器同时支持传统的扁平列表和分组存储，从而统一去重历史的处理。
- 从应用层和基础设施包中导出新的轮询、会话队列和媒体指纹服务类型，并在插件初始化中接好这些服务。

Documentation:
- 更新 PLAN.md，反映配置端口、统一轮询和调度器降级相关架构阶段的完成情况，并标记当前在插件路线图各阶段的进展。
- 在 README 的命令表中文档化新的 `/rss_stop` 命令。

Tests:
- 为 FeedPollingService、RSSScheduler 的新适配器行为、会话推送队列以及扩展后的通知分发器行为添加单元测试，并更新已有的命令和集成测试，以覆盖统一的轮询和排队路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify all feed polling paths through a new FeedPollingService and simplify the RSS scheduler into a timing adapter that delegates polling and notification to application services.

New Features:
- Introduce FeedPollingService as a unified application-level feed polling use case used by manual refresh, Web API refresh, subscription tests, and the scheduler.
- Add a session-scoped push job queue with an /rss_stop command to serialize per-session deliveries and allow cancelling in-flight RSS push tasks.
- Add a media fingerprint port and HTTP-based adapter to compute media content hashes for future deduplication and processing.

Enhancements:
- Refactor RSSScheduler to only handle due subscription selection, grouping by feed, triggering FeedPollingService, and updating next_check_time, while delegating retries and history cleanup to NotificationDispatcher.
- Extend NotificationDispatcher to support session-scoped push queuing, cancellation-aware retry handling, and optional restriction to specific subscription IDs.
- Update refresh and test subscription commands, web API, and FeedSyncService to consume FeedPollingService results instead of talking directly to infrastructure fetchers and parsers.
- Normalize Feed.entry_hashes to support legacy flat lists and grouped storage via a model validator, consolidating dedup history handling.
- Export new polling, session queue, and media fingerprint service types from application and infrastructure packages and wire them into plugin initialization.

Documentation:
- Update PLAN.md to reflect the completion of architecture phases around config ports, unified polling, and scheduler downgrading, and to mark current progress across plugin roadmap phases.
- Document the new /rss_stop command in the README command table.

Tests:
- Add unit tests for FeedPollingService, RSSScheduler’s new adapter behavior, the session push queue, and extended notification dispatcher behavior, and update existing command and integration tests to cover the unified polling and queuing paths.

</details>