### PR TITLE
refactor: separate subscription export read model

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -86,7 +86,7 @@ infrastructure/
 - `[x]` 阶段 2：建立 Application Ports。`FeedFetcher`、`FeedParser`、`MessageSenderProvider`、`Clock` port 已建立，发送器已通过 provider 注入。
 - `[x]` 阶段 3：统一 Feed 同步用例。`FeedPollingService` 已落地，手动 `/refresh`、Web API refresh、scheduler 和 `test_sub` 已统一到同一抓取解析入口。
 - `[x]` 阶段 4：把 Scheduler 降级为 Adapter。`RSSScheduler` 现只负责到期订阅查询、分组触发和下次检查时间回写。
-- `[ ]` 阶段 5：整理 Domain 和 DTO。
+- `[x]` 阶段 5：整理 Domain 和 DTO。`SubscriptionExportRecord` 和导出查询已落地，导出不再往 `Subscription` 挂运行时 `feed`。
 - `[ ]` 阶段 6：清理聚合导出和全局状态。
 
 插件更新计划：
@@ -242,7 +242,7 @@ src/application/ports/
 
 ### 阶段 4：把 Scheduler 降级为 Adapter
 
-状态：`[ ]` 未开始。
+状态：`[x]` 已完成。
 
 目标：`RSSScheduler` 只负责时间触发和订阅到期查询，不承载业务用例。
 
@@ -320,8 +320,8 @@ SubscriptionExportRecord(
 
 验证：
 
-- `[ ]` TOML roundtrip 测试继续通过。
-- `[ ]` `Subscription.model_dump()` 不包含展示关联。
+- `[x]` TOML roundtrip 测试继续通过。
+- `[x]` `Subscription.model_dump()` 不包含展示关联。
 
 ### 阶段 6：清理聚合导出和全局状态
 

--- a/src/application/commands/export_subscriptions_cmd.py
+++ b/src/application/commands/export_subscriptions_cmd.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from ...domain.repositories.feed_repository import FeedRepository
 from ...domain.repositories.subscription_repository import SubscriptionRepository
 from ..dto.result_dto import CommandResult
+from ..queries.get_subscription_exports_query import GetSubscriptionExportsQuery
+from ..services.subscription_serializer import serialize_subscriptions_to_toml
 
 
 @dataclass
@@ -32,8 +34,10 @@ class ExportSubscriptionsCommand:
         subscription_repo: SubscriptionRepository,
         feed_repo: FeedRepository | None = None,
     ):
-        self._subscription_repo = subscription_repo
-        self._feed_repo = feed_repo
+        self._export_query = GetSubscriptionExportsQuery(
+            subscription_repo=subscription_repo,
+            feed_repo=feed_repo,
+        )
 
     async def execute(
         self,
@@ -48,30 +52,18 @@ class ExportSubscriptionsCommand:
         Returns:
             CommandResult: 命令执行结果
         """
-        subscriptions = await self._subscription_repo.get_by_user(user_id)
+        records = await self._export_query.execute(user_id)
 
-        if not subscriptions:
+        if not records:
             return CommandResult(
                 success=False,
                 message="您当前没有可导出的订阅",
             )
 
-        if self._feed_repo is not None:
-            for subscription in subscriptions:
-                if getattr(subscription, "feed", None) is not None:
-                    continue
-                feed = await self._feed_repo.get_by_id(subscription.feed_id)
-                if feed is not None:
-                    subscription.feed = feed
-
         try:
-            from ...application.services.subscription_serializer import (
-                serialize_subscriptions_to_toml,
-            )
-
             content = serialize_subscriptions_to_toml(
                 user_id=user_id,
-                subscriptions=subscriptions,
+                records=records,
             )
 
             from datetime import datetime
@@ -82,12 +74,12 @@ class ExportSubscriptionsCommand:
             result = ExportResult(
                 content=content,
                 filename=filename,
-                count=len(subscriptions),
+                count=len(records),
             )
 
             return CommandResult(
                 success=True,
-                message=f"成功导出 {len(subscriptions)} 个订阅",
+                message=f"成功导出 {len(records)} 个订阅",
                 data=result,
             )
 

--- a/src/application/commands/export_subscriptions_cmd.py
+++ b/src/application/commands/export_subscriptions_cmd.py
@@ -52,7 +52,13 @@ class ExportSubscriptionsCommand:
         Returns:
             CommandResult: 命令执行结果
         """
-        records = await self._export_query.execute(user_id)
+        try:
+            records = await self._export_query.execute(user_id)
+        except RuntimeError as e:
+            return CommandResult(
+                success=False,
+                message=f"导出失败: {e}",
+            )
 
         if not records:
             return CommandResult(

--- a/src/application/dto/__init__.py
+++ b/src/application/dto/__init__.py
@@ -7,12 +7,14 @@ from .feed_dto import FeedDTO
 from .item_dto import ItemDTO
 from .result_dto import CommandResult
 from .subscription_dto import SubscriptionDTO
+from .subscription_export_record import SubscriptionExportRecord
 from .web_feed_dto import WebFeed
 
 __all__ = [
     "CommandResult",
     "FeedDTO",
     "ItemDTO",
+    "SubscriptionExportRecord",
     "SubscriptionDTO",
     "WebFeed",
 ]

--- a/src/application/dto/subscription_export_record.py
+++ b/src/application/dto/subscription_export_record.py
@@ -1,0 +1,69 @@
+"""Subscription export read model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...domain.entities.subscription import Subscription
+
+SUBSCRIPTION_EXPORT_STRING_FIELDS = {
+    "title",
+    "tags",
+    "platform_name",
+    "feed_title",
+    "translate_target_lang",
+}
+
+SUBSCRIPTION_EXPORT_INT_FIELDS = {
+    "notify",
+    "send_mode",
+    "length_limit",
+    "link_preview",
+    "display_author",
+    "display_via",
+    "display_title",
+    "display_entry_tags",
+    "style",
+    "display_media",
+    "interval",
+    "translate",
+}
+
+
+@dataclass(frozen=True)
+class SubscriptionExportRecord:
+    """Feed link and subscription options needed for TOML export."""
+
+    link: str
+    feed_title: str | None = None
+    options: dict[str, int | str] = field(default_factory=dict)
+
+
+def build_subscription_export_record(
+    subscription: Subscription,
+    *,
+    link: str,
+    feed_title: str | None = None,
+) -> SubscriptionExportRecord:
+    """Build the read model used by subscription export."""
+    options: dict[str, int | str] = {}
+
+    for key in sorted(SUBSCRIPTION_EXPORT_STRING_FIELDS - {"feed_title"}):
+        value = getattr(subscription, key, None)
+        if isinstance(value, str) and value.strip():
+            options[key] = value
+
+    for key in sorted(SUBSCRIPTION_EXPORT_INT_FIELDS):
+        value = getattr(subscription, key, None)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            options[key] = value
+
+    return SubscriptionExportRecord(
+        link=link,
+        feed_title=feed_title,
+        options=options,
+    )

--- a/src/application/queries/__init__.py
+++ b/src/application/queries/__init__.py
@@ -2,6 +2,7 @@
 
 from .get_feed_items_query import FeedItemsResult, GetFeedItemsQuery
 from .get_feed_list_query import FeedListResult, GetFeedListQuery
+from .get_subscription_exports_query import GetSubscriptionExportsQuery
 from .get_subscriptions_query import GetSubscriptionsQuery, SubscriptionsResult
 from .search_feeds_query import SearchFeedsQuery, SearchFeedsResult
 
@@ -10,6 +11,7 @@ __all__ = [
     "FeedListResult",
     "GetFeedItemsQuery",
     "GetFeedListQuery",
+    "GetSubscriptionExportsQuery",
     "GetSubscriptionsQuery",
     "SearchFeedsQuery",
     "SearchFeedsResult",

--- a/src/application/queries/get_subscription_exports_query.py
+++ b/src/application/queries/get_subscription_exports_query.py
@@ -1,0 +1,46 @@
+"""Subscription export read-model query."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..dto.subscription_export_record import (
+    SubscriptionExportRecord,
+    build_subscription_export_record,
+)
+
+if TYPE_CHECKING:
+    from ...domain.repositories.feed_repository import FeedRepository
+    from ...domain.repositories.subscription_repository import SubscriptionRepository
+
+
+class GetSubscriptionExportsQuery:
+    """Build export read models for a user's subscriptions."""
+
+    def __init__(
+        self,
+        subscription_repo: SubscriptionRepository,
+        feed_repo: FeedRepository | None = None,
+    ) -> None:
+        self._subscription_repo = subscription_repo
+        self._feed_repo = feed_repo
+
+    async def execute(self, user_id: str) -> list[SubscriptionExportRecord]:
+        """Load subscriptions and hydrate export-ready records."""
+        subscriptions = await self._subscription_repo.get_by_user(user_id)
+        if not subscriptions or self._feed_repo is None:
+            return []
+
+        records: list[SubscriptionExportRecord] = []
+        for subscription in subscriptions:
+            feed = await self._feed_repo.get_by_id(subscription.feed_id)
+            if feed is None:
+                continue
+            records.append(
+                build_subscription_export_record(
+                    subscription,
+                    link=feed.link,
+                    feed_title=feed.title or None,
+                )
+            )
+        return records

--- a/src/application/queries/get_subscription_exports_query.py
+++ b/src/application/queries/get_subscription_exports_query.py
@@ -27,13 +27,25 @@ class GetSubscriptionExportsQuery:
 
     async def execute(self, user_id: str) -> list[SubscriptionExportRecord]:
         """Load subscriptions and hydrate export-ready records."""
+        if self._feed_repo is None:
+            raise RuntimeError("Subscription export requires a feed repository")
+
         subscriptions = await self._subscription_repo.get_by_user(user_id)
-        if not subscriptions or self._feed_repo is None:
+        if not subscriptions:
             return []
+
+        feed_ids = list(
+            dict.fromkeys(subscription.feed_id for subscription in subscriptions)
+        )
+        feeds = {
+            feed.id: feed
+            for feed in await self._feed_repo.get_by_ids(feed_ids)
+            if feed.id is not None
+        }
 
         records: list[SubscriptionExportRecord] = []
         for subscription in subscriptions:
-            feed = await self._feed_repo.get_by_id(subscription.feed_id)
+            feed = feeds.get(subscription.feed_id)
             if feed is None:
                 continue
             records.append(

--- a/src/application/services/subscription_serializer.py
+++ b/src/application/services/subscription_serializer.py
@@ -9,10 +9,12 @@ import json
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from ...domain.entities.subscription import Subscription
+from ..dto.subscription_export_record import (
+    SUBSCRIPTION_EXPORT_INT_FIELDS,
+    SUBSCRIPTION_EXPORT_STRING_FIELDS,
+    SubscriptionExportRecord,
+)
 
 EXPORT_FORMAT = "astrbot-rsshub-subscriptions"
 EXPORT_VERSION = 1
@@ -20,28 +22,8 @@ EXPORT_VERSION = 1
 # 导出时排除的字段（这些是运行时计算的）
 EXPORT_EXCLUDED_FIELDS = {"id", "sid", "sub_id"}
 
-STRING_FIELDS = {
-    "title",
-    "tags",
-    "platform_name",
-    "feed_title",
-    "translate_target_lang",
-}
-
-INT_FIELDS = {
-    "notify",
-    "send_mode",
-    "length_limit",
-    "link_preview",
-    "display_author",
-    "display_via",
-    "display_title",
-    "display_entry_tags",
-    "style",
-    "display_media",
-    "interval",
-    "translate",
-}
+STRING_FIELDS = SUBSCRIPTION_EXPORT_STRING_FIELDS
+INT_FIELDS = SUBSCRIPTION_EXPORT_INT_FIELDS
 
 
 @dataclass
@@ -70,13 +52,13 @@ def _toml_string(value: str) -> str:
 def serialize_subscriptions_to_toml(
     *,
     user_id: str,
-    subscriptions: list[Subscription],
+    records: list[SubscriptionExportRecord],
 ) -> str:
     """将用户订阅序列化为 TOML 文本
 
     Args:
         user_id: 用户 ID
-        subscriptions: 订阅列表
+        records: 导出读模型列表
 
     Returns:
         TOML 格式的订阅配置文本
@@ -89,27 +71,25 @@ def serialize_subscriptions_to_toml(
         "",
     ]
 
-    for sub in subscriptions:
-        feed = getattr(sub, "feed", None)
-        if feed is None:
+    for record in records:
+        if not record.link:
             continue
-
         lines.append("[[subscriptions]]")
-        lines.append(f"link = {_toml_string(str(feed.link))}")
-        if feed.title:
-            lines.append(f"feed_title = {_toml_string(str(feed.title))}")
+        lines.append(f"link = {_toml_string(str(record.link))}")
+        if record.feed_title:
+            lines.append(f"feed_title = {_toml_string(str(record.feed_title))}")
 
         for key in sorted(STRING_FIELDS - {"feed_title"}):
             if key in EXPORT_EXCLUDED_FIELDS:
                 continue
-            value = getattr(sub, key, None)
+            value = record.options.get(key)
             if isinstance(value, str) and value.strip():
                 lines.append(f"{key} = {_toml_string(value)}")
 
         for key in sorted(INT_FIELDS):
             if key in EXPORT_EXCLUDED_FIELDS:
                 continue
-            value = getattr(sub, key, None)
+            value = record.options.get(key)
             if isinstance(value, bool):
                 continue
             if isinstance(value, int):

--- a/src/domain/entities/subscription.py
+++ b/src/domain/entities/subscription.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 
 from ..constants import INHERIT_VALUE
-from .feed import Feed
 
 
 class Subscription(BaseModel):
@@ -57,12 +56,6 @@ class Subscription(BaseModel):
         default=False,
         description="是否使用订阅自身配置: true=使用Sub表, false=继承上层",
     )
-    feed: Feed | None = Field(
-        default=None,
-        exclude=True,
-        description="关联 Feed，仅用于导出和展示等运行时读模型",
-    )
-
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc), description="创建时间"
     )

--- a/src/domain/repositories/feed_repository.py
+++ b/src/domain/repositories/feed_repository.py
@@ -28,6 +28,18 @@ class FeedRepository(Protocol):
         """
         ...
 
+    async def get_by_ids(self, feed_ids: list[int]) -> list[Feed]:
+        """
+        根据ID批量获取Feed
+
+        Args:
+            feed_ids: Feed唯一标识列表
+
+        Returns:
+            Feed对象列表
+        """
+        ...
+
     async def get_by_link(self, link: str) -> Feed | None:
         """
         根据链接获取Feed

--- a/src/infrastructure/persistence/feed_repository_impl.py
+++ b/src/infrastructure/persistence/feed_repository_impl.py
@@ -27,6 +27,19 @@ class FeedRepositoryImpl:
             orm = await session.get(FeedORM, feed_id)
             return self._to_entity(orm) if orm else None
 
+    async def get_by_ids(self, feed_ids: list[int]) -> list[Feed]:
+        """根据ID批量获取Feed"""
+        ids = list(dict.fromkeys(feed_ids))
+        if not ids:
+            return []
+
+        db = get_database()
+        async with db.get_session() as session:
+            stmt = select(FeedORM).where(FeedORM.id.in_(ids))
+            result = await session.execute(stmt)
+            orms = result.scalars().all()
+            return [self._to_entity(orm) for orm in orms]
+
     async def get_by_link(self, link: str) -> Feed | None:
         """根据链接获取Feed"""
         db = get_database()

--- a/tests/unit/application/test_import_export.py
+++ b/tests/unit/application/test_import_export.py
@@ -252,7 +252,9 @@ class TestExportCommand:
         assert feed_repo.calls == [[1]]
 
     @pytest.mark.asyncio
-    async def test_export_uses_bulk_feed_lookup_for_multiple_subscriptions(self) -> None:
+    async def test_export_uses_bulk_feed_lookup_for_multiple_subscriptions(
+        self,
+    ) -> None:
         subscriptions = [
             Subscription(user_id="user-001", feed_id=1, title="First"),
             Subscription(user_id="user-001", feed_id=2, title="Second"),

--- a/tests/unit/application/test_import_export.py
+++ b/tests/unit/application/test_import_export.py
@@ -223,13 +223,19 @@ class TestExportCommand:
                 return [subscription]
 
         class FeedRepo:
-            async def get_by_id(self, feed_id: int) -> Feed | None:
-                assert feed_id == 1
-                return feed
+            calls: list[list[int]]
 
+            def __init__(self) -> None:
+                self.calls = []
+
+            async def get_by_ids(self, feed_ids: list[int]) -> list[Feed]:
+                self.calls.append(feed_ids)
+                return [feed]
+
+        feed_repo = FeedRepo()
         command = ExportSubscriptionsCommand(
             subscription_repo=SubscriptionRepo(),
-            feed_repo=FeedRepo(),
+            feed_repo=feed_repo,
         )
 
         result = await command.execute("user-001")
@@ -243,6 +249,72 @@ class TestExportCommand:
         assert payload.records[0].options["title"] == "Hydrated"
         assert "feed" not in subscription.model_dump()
         assert not hasattr(subscription, "feed")
+        assert feed_repo.calls == [[1]]
+
+    @pytest.mark.asyncio
+    async def test_export_uses_bulk_feed_lookup_for_multiple_subscriptions(self) -> None:
+        subscriptions = [
+            Subscription(user_id="user-001", feed_id=1, title="First"),
+            Subscription(user_id="user-001", feed_id=2, title="Second"),
+            Subscription(user_id="user-001", feed_id=1, title="Duplicate feed"),
+        ]
+        feeds = {
+            1: Feed(id=1, link="https://example.com/feed-1.xml", title="Feed 1"),
+            2: Feed(id=2, link="https://example.com/feed-2.xml", title="Feed 2"),
+        }
+
+        class SubscriptionRepo:
+            async def get_by_user(self, user_id: str) -> list[Subscription]:
+                assert user_id == "user-001"
+                return subscriptions
+
+        class FeedRepo:
+            calls: list[list[int]]
+
+            def __init__(self) -> None:
+                self.calls = []
+
+            async def get_by_ids(self, feed_ids: list[int]) -> list[Feed]:
+                self.calls.append(feed_ids)
+                return [feeds[feed_id] for feed_id in feed_ids]
+
+            async def get_by_id(self, feed_id: int) -> Feed | None:
+                raise AssertionError("export should use bulk feed lookup")
+
+        feed_repo = FeedRepo()
+        command = ExportSubscriptionsCommand(
+            subscription_repo=SubscriptionRepo(),
+            feed_repo=feed_repo,
+        )
+
+        result = await command.execute("user-001")
+        payload = parse_subscriptions_toml(result.data.content)
+
+        assert result.success is True
+        assert payload.errors == []
+        assert [record.link for record in payload.records] == [
+            "https://example.com/feed-1.xml",
+            "https://example.com/feed-2.xml",
+            "https://example.com/feed-1.xml",
+        ]
+        assert feed_repo.calls == [[1, 2]]
+
+    @pytest.mark.asyncio
+    async def test_export_without_feed_repo_reports_explicit_error(self) -> None:
+        class SubscriptionRepo:
+            async def get_by_user(self, user_id: str) -> list[Subscription]:
+                assert user_id == "user-001"
+                return [Subscription(user_id="user-001", feed_id=1)]
+
+        command = ExportSubscriptionsCommand(
+            subscription_repo=SubscriptionRepo(),
+            feed_repo=None,
+        )
+
+        result = await command.execute("user-001")
+
+        assert result.success is False
+        assert "feed repository" in result.message
 
 
 def test_subscription_model_dump_does_not_include_feed_relation() -> None:

--- a/tests/unit/application/test_import_export.py
+++ b/tests/unit/application/test_import_export.py
@@ -6,6 +6,10 @@ import pytest
 from astrbot_plugin_rsshub.src.application.commands.export_subscriptions_cmd import (
     ExportSubscriptionsCommand,
 )
+from astrbot_plugin_rsshub.src.application.dto.subscription_export_record import (
+    SubscriptionExportRecord,
+    build_subscription_export_record,
+)
 from astrbot_plugin_rsshub.src.application.services.subscription_serializer import (
     parse_subscriptions_toml,
     serialize_subscriptions_to_toml,
@@ -14,29 +18,32 @@ from astrbot_plugin_rsshub.src.domain.entities.feed import Feed
 from astrbot_plugin_rsshub.src.domain.entities.subscription import Subscription
 
 
-def make_subscription(
+def make_export_record(
     *,
     feed_id: int = 1,
     link: str = "https://example.com/feed.xml",
     feed_title: str = "Example Feed",
     **fields: object,
-) -> Subscription:
-    """Create a Subscription with its runtime Feed relation attached."""
+) -> SubscriptionExportRecord:
+    """Create an export read model from a Subscription and Feed metadata."""
     data = {
         "user_id": "user-001",
         "feed_id": feed_id,
         **fields,
     }
     subscription = Subscription(**data)
-    subscription.feed = Feed(id=feed_id, link=link, title=feed_title)
-    return subscription
+    return build_subscription_export_record(
+        subscription,
+        link=link,
+        feed_title=feed_title,
+    )
 
 
 class TestTOMLRoundtrip:
     """Verify export and parse are stable for subscription settings."""
 
     def test_roundtrip_single_subscription(self) -> None:
-        subscription = make_subscription(
+        record = make_export_record(
             title="Timeline",
             tags="twitter,art",
             notify=1,
@@ -45,7 +52,7 @@ class TestTOMLRoundtrip:
 
         content = serialize_subscriptions_to_toml(
             user_id="user-001",
-            subscriptions=[subscription],
+            records=[record],
         )
         payload = parse_subscriptions_toml(content)
 
@@ -61,18 +68,18 @@ class TestTOMLRoundtrip:
 
     def test_roundtrip_multiple_subscriptions(self) -> None:
         subscriptions = [
-            make_subscription(
+            make_export_record(
                 feed_id=1,
                 link="https://example.com/feed-1.xml",
                 feed_title="Feed 1",
             ),
-            make_subscription(
+            make_export_record(
                 feed_id=2,
                 link="https://example.com/feed-2.xml",
                 feed_title="Feed 2",
                 title="Second",
             ),
-            make_subscription(
+            make_export_record(
                 feed_id=3,
                 link="https://example.com/feed-3.xml",
                 feed_title="Feed 3",
@@ -82,7 +89,7 @@ class TestTOMLRoundtrip:
 
         content = serialize_subscriptions_to_toml(
             user_id="user-001",
-            subscriptions=subscriptions,
+            records=subscriptions,
         )
         payload = parse_subscriptions_toml(content)
 
@@ -99,7 +106,7 @@ class TestTOMLRoundtrip:
         ]
 
     def test_roundtrip_preserves_options(self) -> None:
-        subscription = make_subscription(
+        record = make_export_record(
             title="Configured",
             tags="alerts,news",
             platform_name="telegram",
@@ -120,7 +127,7 @@ class TestTOMLRoundtrip:
 
         content = serialize_subscriptions_to_toml(
             user_id="user-001",
-            subscriptions=[subscription],
+            records=[record],
         )
         payload = parse_subscriptions_toml(content)
 
@@ -203,7 +210,7 @@ class TestTOMLParsing:
 
 
 class TestExportCommand:
-    """Verify the export command hydrates Feed data before serializing."""
+    """Verify the export command uses Feed data without mutating subscriptions."""
 
     @pytest.mark.asyncio
     async def test_export_hydrates_feed_for_subscription(self) -> None:
@@ -234,3 +241,12 @@ class TestExportCommand:
         assert payload.records[0].link == "https://example.com/feed.xml"
         assert payload.records[0].feed_title == "Hydrated Feed"
         assert payload.records[0].options["title"] == "Hydrated"
+        assert "feed" not in subscription.model_dump()
+        assert not hasattr(subscription, "feed")
+
+
+def test_subscription_model_dump_does_not_include_feed_relation() -> None:
+    subscription = Subscription(user_id="user-001", feed_id=1)
+
+    assert "feed" not in subscription.model_dump()
+    assert not hasattr(subscription, "feed")


### PR DESCRIPTION
## Summary
- add SubscriptionExportRecord and GetSubscriptionExportsQuery for subscription export read models
- remove the runtime feed relation from Subscription
- update TOML export serialization and tests to use export records
- mark PLAN.md stage 5 as complete

## Tests
- pytest -p no:cacheprovider tests/unit/application tests/integration/test_plugin_integration.py -q
- python tests/run_tests.py -v
- uv run ruff check .
- uv run ruff format --check .

## Summary by Sourcery

引入专门的订阅导出读取模型和查询，并更新订阅导出逻辑，改为使用这些模型和查询，而不是通过运行时的 feed 关联来修改 `Subscription`。

新功能：
- 添加 `SubscriptionExportRecord` DTO 和 `GetSubscriptionExportsQuery`，用于表示并获取可导出的订阅数据。

增强：
- 优化 TOML 订阅导出逻辑，使其基于导出记录和选项映射（option maps）而非 `Subscription` 实体工作。
- 从 `Subscription` 领域实体中移除运行时的 `Feed` 关联，使其不再包含仅用于导出的状态。

文档：
- 更新 `PLAN.md`，将领域/DTO 重构阶段标记为已完成，并记录新的导出读取模型设计。

测试：
- 调整并扩展导入/导出测试，用于覆盖新的导出读取模型，并确保 `Subscription` 不再暴露 feed 关联。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated subscription export read model and query, and update subscription export to use them instead of mutating Subscription with a runtime feed relation.

New Features:
- Add SubscriptionExportRecord DTO and GetSubscriptionExportsQuery to represent and fetch export-ready subscription data.

Enhancements:
- Refine TOML subscription export to work with export records and option maps rather than Subscription entities.
- Remove the runtime Feed relation from the Subscription domain entity to keep it free of export-only state.

Documentation:
- Update PLAN.md to mark the domain/DTO refactor stage as completed and record the new export read model design.

Tests:
- Adjust and extend import/export tests to cover the new export read model and ensure Subscription no longer exposes a feed relation.

</details>