### PR TITLE
fix: self-heal v2 profile schema columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - 修复部分 RSS 源只推送图片不推送正文的问题，补齐 `content:encoded`、HTML 文本提取、图文 layout fragment 和平台发送顺序处理。
+- 修复旧库迁移到 v2 后 `rsshub_sub.handlers_mode` 缺失导致 `/sub_list` 查询失败的问题。
 - 修复失败重试和推送历史审计链路：推送历史保存媒体 URL、原始 XML、handler trace，并限制失败原因长度。
 - 修复 Routes KB raw URL 拼接，支持代理前缀形式的 GitHub Raw 镜像。
 

--- a/src/infrastructure/persistence/database.py
+++ b/src/infrastructure/persistence/database.py
@@ -25,6 +25,7 @@ from sqlmodel import SQLModel
 from ..utils import get_logger
 from .migrations import (
     cleanup_legacy_translation_tables,
+    ensure_profile_schema,
     ensure_push_history_schema,
     run_migrations,
 )
@@ -91,6 +92,7 @@ class DatabaseManager:
             await conn.run_sync(RSSHubBaseModel.metadata.create_all)
             await run_migrations(conn)
             await cleanup_legacy_translation_tables(conn)
+            await ensure_profile_schema(conn)
             await ensure_push_history_schema(conn)
 
         logger.info("RSS 数据库初始化完成: %s", db_path)

--- a/src/infrastructure/persistence/migrations/__init__.py
+++ b/src/infrastructure/persistence/migrations/__init__.py
@@ -7,6 +7,7 @@
 from .migration_runner import (
     MigrationRunner,
     cleanup_legacy_translation_tables,
+    ensure_profile_schema,
     ensure_push_history_schema,
     run_migrations,
 )
@@ -14,6 +15,7 @@ from .migration_runner import (
 __all__ = [
     "MigrationRunner",
     "run_migrations",
+    "ensure_profile_schema",
     "ensure_push_history_schema",
     "cleanup_legacy_translation_tables",
 ]

--- a/src/infrastructure/persistence/migrations/migration_runner.py
+++ b/src/infrastructure/persistence/migrations/migration_runner.py
@@ -329,6 +329,78 @@ async def ensure_push_history_schema(conn) -> list[str]:
     return applied
 
 
+async def ensure_profile_schema(conn) -> list[str]:
+    """补齐当前用户/订阅配置表运行必需字段。
+
+    v2 发布前曾压缩开发期迁移脚本。已有测试库可能已经记录 V1，
+    但实际 `rsshub_sub` 表仍缺少后续基线字段；这里保留轻量自愈，
+    避免查询 ORM 当前模型时因缺列失败。
+    """
+
+    async def _table_exists(table: str) -> bool:
+        result = await conn.exec_driver_sql(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        )
+        return result.fetchone() is not None
+
+    async def _column_names(table: str) -> set[str]:
+        result = await conn.exec_driver_sql(f"PRAGMA table_info({table})")
+        return {str(row[1]) for row in result.fetchall()}
+
+    applied: list[str] = []
+
+    if await _table_exists("rsshub_user"):
+        user_columns = await _column_names("rsshub_user")
+        if "handlers" not in user_columns:
+            await conn.exec_driver_sql(
+                "ALTER TABLE rsshub_user ADD COLUMN handlers TEXT NOT NULL DEFAULT '[]'"
+            )
+            applied.append("rsshub_user.handlers")
+            logger.info("数据库 schema 自愈: 为 rsshub_user 添加 handlers 字段")
+
+    if await _table_exists("rsshub_sub"):
+        sub_columns = await _column_names("rsshub_sub")
+        if "handlers" not in sub_columns:
+            await conn.exec_driver_sql(
+                "ALTER TABLE rsshub_sub ADD COLUMN handlers TEXT NOT NULL DEFAULT '[]'"
+            )
+            applied.append("rsshub_sub.handlers")
+            logger.info("数据库 schema 自愈: 为 rsshub_sub 添加 handlers 字段")
+            sub_columns.add("handlers")
+        if "handlers_mode" not in sub_columns:
+            await conn.exec_driver_sql(
+                "ALTER TABLE rsshub_sub ADD COLUMN handlers_mode TEXT NOT NULL DEFAULT 'inherit'"
+            )
+            await conn.exec_driver_sql(
+                """
+                UPDATE rsshub_sub
+                SET handlers_mode = CASE
+                    WHEN handlers IS NULL THEN 'inherit'
+                    WHEN json_valid(handlers) AND json_array_length(handlers) = 0 THEN 'inherit'
+                    WHEN NOT json_valid(handlers) AND REPLACE(
+                        REPLACE(
+                            REPLACE(
+                                REPLACE(TRIM(COALESCE(handlers, '[]')), ' ', ''),
+                                CHAR(10),
+                                ''
+                            ),
+                            CHAR(13),
+                            ''
+                        ),
+                        CHAR(9),
+                        ''
+                    ) IN ('', '[]') THEN 'inherit'
+                    ELSE 'override'
+                END
+                """
+            )
+            applied.append("rsshub_sub.handlers_mode")
+            logger.info("数据库 schema 自愈: 为 rsshub_sub 添加 handlers_mode 字段")
+
+    return applied
+
+
 async def cleanup_legacy_translation_tables(conn) -> list[str]:
     """删除已废弃的翻译缓存相关表。
 

--- a/tests/unit/infrastructure/test_database_manager.py
+++ b/tests/unit/infrastructure/test_database_manager.py
@@ -10,7 +10,10 @@ from astrbot_plugin_rsshub.src.infrastructure.persistence.migrations import (
     ensure_profile_schema,
     ensure_push_history_schema,
 )
+from astrbot_plugin_rsshub.src.infrastructure.persistence.models import SubORM
 from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 
 def test_database_is_initialized_requires_session_maker():
@@ -161,6 +164,76 @@ async def test_ensure_profile_schema_adds_handlers_mode_to_existing_sub_table():
         assert "handlers_mode" in sub_columns
         assert rows == [(1, "inherit"), (2, "override")]
 
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_ensure_profile_schema_allows_current_sub_orm_reads():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(
+            """
+            CREATE TABLE rsshub_user (
+                id VARCHAR PRIMARY KEY
+            )
+            """
+        )
+        await conn.exec_driver_sql(
+            """
+            CREATE TABLE rsshub_feed (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                link VARCHAR NOT NULL,
+                title VARCHAR NOT NULL
+            )
+            """
+        )
+        await conn.exec_driver_sql(
+            """
+            CREATE TABLE rsshub_sub (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                state INTEGER NOT NULL DEFAULT 1,
+                user_id VARCHAR NOT NULL,
+                feed_id INTEGER NOT NULL,
+                title VARCHAR NOT NULL DEFAULT '',
+                tags VARCHAR NOT NULL DEFAULT '',
+                target_session VARCHAR,
+                platform_name VARCHAR,
+                interval INTEGER NOT NULL DEFAULT -100,
+                next_check_time DATETIME,
+                notify INTEGER NOT NULL DEFAULT -100,
+                send_mode INTEGER NOT NULL DEFAULT -100,
+                length_limit INTEGER NOT NULL DEFAULT -100,
+                display_author INTEGER NOT NULL DEFAULT -100,
+                display_via INTEGER NOT NULL DEFAULT -100,
+                display_title INTEGER NOT NULL DEFAULT -100,
+                display_entry_tags INTEGER NOT NULL DEFAULT -100,
+                style INTEGER NOT NULL DEFAULT -100,
+                display_media INTEGER NOT NULL DEFAULT -100,
+                handlers TEXT NOT NULL DEFAULT '[]',
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        await conn.exec_driver_sql("INSERT INTO rsshub_user (id) VALUES ('u1')")
+        await conn.exec_driver_sql(
+            "INSERT INTO rsshub_feed (id, link, title) VALUES (1, 'https://example.com/rss', 'Feed')"
+        )
+        await conn.exec_driver_sql(
+            """
+            INSERT INTO rsshub_sub (id, user_id, feed_id, title, handlers)
+            VALUES (1, 'u1', 1, 'Sub', '[]')
+            """
+        )
+
+        await ensure_profile_schema(conn)
+
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        sub = await session.get(SubORM, 1)
+
+    assert sub is not None
+    assert sub.handlers_mode == "inherit"
     await engine.dispose()
 
 

--- a/tests/unit/infrastructure/test_database_manager.py
+++ b/tests/unit/infrastructure/test_database_manager.py
@@ -7,6 +7,7 @@ from astrbot_plugin_rsshub.src.infrastructure.persistence.database import (
 from astrbot_plugin_rsshub.src.infrastructure.persistence.migrations import (
     MigrationRunner,
     cleanup_legacy_translation_tables,
+    ensure_profile_schema,
     ensure_push_history_schema,
 )
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -99,6 +100,68 @@ async def test_cleanup_legacy_translation_tables_drops_existing_tables():
     executed_sql = "\n".join(sql for sql, _ in conn.executed)
     assert "DROP TABLE IF EXISTS rsshub_translation_cache" in executed_sql
     assert "DROP TABLE IF EXISTS rsshub_translate_history" in executed_sql
+
+
+@pytest.mark.asyncio
+async def test_ensure_profile_schema_adds_handlers_mode_to_existing_sub_table():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(
+            """
+            CREATE TABLE rsshub_user (
+                id VARCHAR PRIMARY KEY
+            )
+            """
+        )
+        await conn.exec_driver_sql(
+            """
+            CREATE TABLE rsshub_sub (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id VARCHAR NOT NULL,
+                handlers TEXT NOT NULL DEFAULT '[]'
+            )
+            """
+        )
+        await conn.exec_driver_sql(
+            """
+            INSERT INTO rsshub_user (id) VALUES ('u1')
+            """
+        )
+        await conn.exec_driver_sql(
+            """
+            INSERT INTO rsshub_sub (id, user_id, handlers)
+            VALUES
+                (1, 'u1', '[]'),
+                (2, 'u1', '[{"id":"builtin.ai_filter.default"}]')
+            """
+        )
+
+        applied = await ensure_profile_schema(conn)
+
+        assert applied == ["rsshub_user.handlers", "rsshub_sub.handlers_mode"]
+        sub_columns = {
+            str(row[1])
+            for row in (
+                await conn.exec_driver_sql("PRAGMA table_info(rsshub_sub)")
+            ).fetchall()
+        }
+        user_columns = {
+            str(row[1])
+            for row in (
+                await conn.exec_driver_sql("PRAGMA table_info(rsshub_user)")
+            ).fetchall()
+        }
+        rows = (
+            await conn.exec_driver_sql(
+                "SELECT id, handlers_mode FROM rsshub_sub ORDER BY id"
+            )
+        ).fetchall()
+
+        assert "handlers" in user_columns
+        assert "handlers_mode" in sub_columns
+        assert rows == [(1, "inherit"), (2, "override")]
+
+    await engine.dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add startup self-heal for v2 profile columns on existing databases.
- Restore missing rsshub_sub.handlers_mode, rsshub_sub.handlers, and rsshub_user.handlers when migration history is already marked complete.
- Backfill handlers_mode from existing handler JSON so /sub_list and subscription queries do not crash after v2 migration.

## Tests
- uv run ruff check src/infrastructure/persistence/migrations/migration_runner.py src/infrastructure/persistence/migrations/__init__.py src/infrastructure/persistence/database.py tests/unit/infrastructure/test_database_manager.py
- uv run pytest tests/unit/infrastructure/test_database_manager.py -q

## Summary by Sourcery

在启动时新增自愈步骤，以确保现有数据库中存在所需的 v2 profile schema 列，从而防止迁移后订阅相关查询失败。

Bug Fixes:
- 确保在旧版数据库中补齐缺失的 `rsshub_user.handlers`、`rsshub_sub.handlers` 和 `rsshub_sub.handlers_mode` 列，使与 profile 相关的查询在 v2 迁移后不再崩溃。

Enhancements:
- 将 profile schema 的自愈逻辑集成到数据库初始化过程中，并通过 migrations 包对该辅助方法进行暴露，以便复用。

Documentation:
- 更新 changelog，记录修复缺失 `rsshub_sub.handlers_mode` 导致迁移后数据库上的 `/sub_list` 请求失败的问题。

Tests:
- 增加单元测试覆盖，验证 profile schema 自愈逻辑会补齐缺失列，并能基于已有 handler 数据正确回填 `handlers_mode`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a startup self-healing step to ensure required v2 profile schema columns exist on existing databases and prevent subscription queries from failing after migration.

Bug Fixes:
- Ensure missing rsshub_user.handlers, rsshub_sub.handlers, and rsshub_sub.handlers_mode columns are added to legacy databases so profile-related queries no longer crash after v2 migration.

Enhancements:
- Integrate profile schema self-healing into database initialization and expose the helper via the migrations package for reuse.

Documentation:
- Update the changelog to document the fix for missing rsshub_sub.handlers_mode causing /sub_list failures on migrated databases.

Tests:
- Add unit test coverage to verify profile schema self-healing adds missing columns and correctly backfills handlers_mode based on existing handler data.

</details>