### PR TITLE
fix: normalize null profile option values

### DIFF
--- a/src/infrastructure/persistence/migrations/migration_runner.py
+++ b/src/infrastructure/persistence/migrations/migration_runner.py
@@ -349,7 +349,9 @@ async def ensure_profile_schema(conn) -> list[str]:
         result = await conn.exec_driver_sql(f"PRAGMA table_info({table})")
         return {str(row[1]) for row in result.fetchall()}
 
-    async def _fill_nulls(table: str, columns: set[str], defaults: dict[str, Any]) -> list[str]:
+    async def _fill_nulls(
+        table: str, columns: set[str], defaults: dict[str, Any]
+    ) -> list[str]:
         fixed: list[str] = []
         for column, default in defaults.items():
             if column not in columns:

--- a/src/infrastructure/persistence/migrations/migration_runner.py
+++ b/src/infrastructure/persistence/migrations/migration_runner.py
@@ -22,10 +22,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ....domain.entities.handlers import handlers_json
+from ....domain.entities.subscription import (
+    HANDLERS_MODE_INHERIT,
+    HANDLERS_MODE_OVERRIDE,
+)
 from ....shared.constants import INHERIT_VALUE, STATE_ENABLED, USER_STATE_USER
 from ...utils import get_logger
 
 logger = get_logger()
+DEFAULT_HANDLERS_JSON = handlers_json([])
 
 # 匹配迁移文件名: V1_init.py
 _MIGRATION_PATTERN = re.compile(r"^V(\d+)_.+\.py$")
@@ -364,6 +370,18 @@ async def ensure_profile_schema(conn) -> list[str]:
                 fixed.append(f"{table}.{column}.nulls")
         return fixed
 
+    async def _fill_timestamp_nulls(table: str, columns: set[str]) -> list[str]:
+        fixed: list[str] = []
+        for column in ("created_at", "updated_at"):
+            if column not in columns:
+                continue
+            result = await conn.exec_driver_sql(
+                f"UPDATE {table} SET {column} = CURRENT_TIMESTAMP WHERE {column} IS NULL"
+            )
+            if result.rowcount and result.rowcount > 0:
+                fixed.append(f"{table}.{column}.nulls")
+        return fixed
+
     applied: list[str] = []
 
     if await _table_exists("rsshub_user"):
@@ -383,7 +401,7 @@ async def ensure_profile_schema(conn) -> list[str]:
                 "interval": INHERIT_VALUE,
                 "notify": INHERIT_VALUE,
                 "send_mode": INHERIT_VALUE,
-                "handlers": "[]",
+                "handlers": DEFAULT_HANDLERS_JSON,
                 "length_limit": INHERIT_VALUE,
                 "display_author": INHERIT_VALUE,
                 "display_via": INHERIT_VALUE,
@@ -397,13 +415,10 @@ async def ensure_profile_schema(conn) -> list[str]:
         if fixed:
             applied.extend(fixed)
             logger.info("数据库 schema 自愈: 修正 rsshub_user 的 NULL 配置字段")
-        if {"created_at", "updated_at"}.issubset(user_columns):
-            await conn.exec_driver_sql(
-                "UPDATE rsshub_user SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"
-            )
-            await conn.exec_driver_sql(
-                "UPDATE rsshub_user SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"
-            )
+        fixed = await _fill_timestamp_nulls("rsshub_user", user_columns)
+        if fixed:
+            applied.extend(fixed)
+            logger.info("数据库 schema 自愈: 修正 rsshub_user 的 NULL 时间字段")
 
     if await _table_exists("rsshub_sub"):
         sub_columns = await _column_names("rsshub_sub")
@@ -416,18 +431,18 @@ async def ensure_profile_schema(conn) -> list[str]:
             sub_columns.add("handlers")
         if "handlers_mode" not in sub_columns:
             await conn.exec_driver_sql(
-                "ALTER TABLE rsshub_sub ADD COLUMN handlers_mode TEXT NOT NULL DEFAULT 'inherit'"
+                f"ALTER TABLE rsshub_sub ADD COLUMN handlers_mode TEXT NOT NULL DEFAULT '{HANDLERS_MODE_INHERIT}'"
             )
             await conn.exec_driver_sql(
-                """
+                f"""
                 UPDATE rsshub_sub
                 SET handlers_mode = CASE
-                    WHEN handlers IS NULL THEN 'inherit'
-                    WHEN json_valid(handlers) AND json_array_length(handlers) = 0 THEN 'inherit'
+                    WHEN handlers IS NULL THEN '{HANDLERS_MODE_INHERIT}'
+                    WHEN json_valid(handlers) AND json_array_length(handlers) = 0 THEN '{HANDLERS_MODE_INHERIT}'
                     WHEN NOT json_valid(handlers) AND REPLACE(
                         REPLACE(
                             REPLACE(
-                                REPLACE(TRIM(COALESCE(handlers, '[]')), ' ', ''),
+                                REPLACE(TRIM(COALESCE(handlers, '{DEFAULT_HANDLERS_JSON}')), ' ', ''),
                                 CHAR(10),
                                 ''
                             ),
@@ -436,8 +451,8 @@ async def ensure_profile_schema(conn) -> list[str]:
                         ),
                         CHAR(9),
                         ''
-                    ) IN ('', '[]') THEN 'inherit'
-                    ELSE 'override'
+                    ) IN ('', '{DEFAULT_HANDLERS_JSON}') THEN '{HANDLERS_MODE_INHERIT}'
+                    ELSE '{HANDLERS_MODE_OVERRIDE}'
                 END
                 """
             )
@@ -454,8 +469,8 @@ async def ensure_profile_schema(conn) -> list[str]:
                 "interval": INHERIT_VALUE,
                 "notify": INHERIT_VALUE,
                 "send_mode": INHERIT_VALUE,
-                "handlers": "[]",
-                "handlers_mode": "inherit",
+                "handlers": DEFAULT_HANDLERS_JSON,
+                "handlers_mode": HANDLERS_MODE_INHERIT,
                 "length_limit": INHERIT_VALUE,
                 "display_author": INHERIT_VALUE,
                 "display_via": INHERIT_VALUE,
@@ -468,13 +483,10 @@ async def ensure_profile_schema(conn) -> list[str]:
         if fixed:
             applied.extend(fixed)
             logger.info("数据库 schema 自愈: 修正 rsshub_sub 的 NULL 配置字段")
-        if {"created_at", "updated_at"}.issubset(sub_columns):
-            await conn.exec_driver_sql(
-                "UPDATE rsshub_sub SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"
-            )
-            await conn.exec_driver_sql(
-                "UPDATE rsshub_sub SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"
-            )
+        fixed = await _fill_timestamp_nulls("rsshub_sub", sub_columns)
+        if fixed:
+            applied.extend(fixed)
+            logger.info("数据库 schema 自愈: 修正 rsshub_sub 的 NULL 时间字段")
 
     return applied
 

--- a/src/infrastructure/persistence/migrations/migration_runner.py
+++ b/src/infrastructure/persistence/migrations/migration_runner.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ....shared.constants import INHERIT_VALUE, STATE_ENABLED, USER_STATE_USER
 from ...utils import get_logger
 
 logger = get_logger()
@@ -348,6 +349,19 @@ async def ensure_profile_schema(conn) -> list[str]:
         result = await conn.exec_driver_sql(f"PRAGMA table_info({table})")
         return {str(row[1]) for row in result.fetchall()}
 
+    async def _fill_nulls(table: str, columns: set[str], defaults: dict[str, Any]) -> list[str]:
+        fixed: list[str] = []
+        for column, default in defaults.items():
+            if column not in columns:
+                continue
+            result = await conn.exec_driver_sql(
+                f"UPDATE {table} SET {column} = ? WHERE {column} IS NULL",
+                (default,),
+            )
+            if result.rowcount and result.rowcount > 0:
+                fixed.append(f"{table}.{column}.nulls")
+        return fixed
+
     applied: list[str] = []
 
     if await _table_exists("rsshub_user"):
@@ -358,6 +372,36 @@ async def ensure_profile_schema(conn) -> list[str]:
             )
             applied.append("rsshub_user.handlers")
             logger.info("数据库 schema 自愈: 为 rsshub_user 添加 handlers 字段")
+            user_columns.add("handlers")
+        fixed = await _fill_nulls(
+            "rsshub_user",
+            user_columns,
+            {
+                "state": USER_STATE_USER,
+                "interval": INHERIT_VALUE,
+                "notify": INHERIT_VALUE,
+                "send_mode": INHERIT_VALUE,
+                "handlers": "[]",
+                "length_limit": INHERIT_VALUE,
+                "display_author": INHERIT_VALUE,
+                "display_via": INHERIT_VALUE,
+                "display_title": INHERIT_VALUE,
+                "display_entry_tags": INHERIT_VALUE,
+                "style": INHERIT_VALUE,
+                "display_media": INHERIT_VALUE,
+                "needs_binding_notice": 0,
+            },
+        )
+        if fixed:
+            applied.extend(fixed)
+            logger.info("数据库 schema 自愈: 修正 rsshub_user 的 NULL 配置字段")
+        if {"created_at", "updated_at"}.issubset(user_columns):
+            await conn.exec_driver_sql(
+                "UPDATE rsshub_user SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"
+            )
+            await conn.exec_driver_sql(
+                "UPDATE rsshub_user SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"
+            )
 
     if await _table_exists("rsshub_sub"):
         sub_columns = await _column_names("rsshub_sub")
@@ -397,6 +441,38 @@ async def ensure_profile_schema(conn) -> list[str]:
             )
             applied.append("rsshub_sub.handlers_mode")
             logger.info("数据库 schema 自愈: 为 rsshub_sub 添加 handlers_mode 字段")
+            sub_columns.add("handlers_mode")
+        fixed = await _fill_nulls(
+            "rsshub_sub",
+            sub_columns,
+            {
+                "state": STATE_ENABLED,
+                "title": "",
+                "tags": "",
+                "interval": INHERIT_VALUE,
+                "notify": INHERIT_VALUE,
+                "send_mode": INHERIT_VALUE,
+                "handlers": "[]",
+                "handlers_mode": "inherit",
+                "length_limit": INHERIT_VALUE,
+                "display_author": INHERIT_VALUE,
+                "display_via": INHERIT_VALUE,
+                "display_title": INHERIT_VALUE,
+                "display_entry_tags": INHERIT_VALUE,
+                "style": INHERIT_VALUE,
+                "display_media": INHERIT_VALUE,
+            },
+        )
+        if fixed:
+            applied.extend(fixed)
+            logger.info("数据库 schema 自愈: 修正 rsshub_sub 的 NULL 配置字段")
+        if {"created_at", "updated_at"}.issubset(sub_columns):
+            await conn.exec_driver_sql(
+                "UPDATE rsshub_sub SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"
+            )
+            await conn.exec_driver_sql(
+                "UPDATE rsshub_sub SET updated_at = CURRENT_TIMESTAMP WHERE updated_at IS NULL"
+            )
 
     return applied
 

--- a/tests/unit/infrastructure/test_database_manager.py
+++ b/tests/unit/infrastructure/test_database_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from astrbot_plugin_rsshub.src.domain.entities.handlers import handlers_json
+from astrbot_plugin_rsshub.src.domain.entities.subscription import HANDLERS_MODE_INHERIT
 from astrbot_plugin_rsshub.src.infrastructure.persistence.database import (
     DatabaseManager,
 )
@@ -14,6 +16,7 @@ from astrbot_plugin_rsshub.src.infrastructure.persistence.models import SubORM
 from astrbot_plugin_rsshub.src.infrastructure.persistence.subscription_repository_impl import (
     SubscriptionRepositoryImpl,
 )
+from astrbot_plugin_rsshub.src.shared.constants import INHERIT_VALUE, STATE_ENABLED
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -236,11 +239,38 @@ async def test_ensure_profile_schema_allows_current_sub_orm_reads():
         sub = await session.get(SubORM, 1)
 
     assert sub is not None
-    assert SubscriptionRepositoryImpl._to_entity(sub).interval == -100
-    assert sub.handlers_mode == "inherit"
-    assert sub.interval == -100
+    entity = SubscriptionRepositoryImpl._to_entity(sub)
+
+    expected_options = {
+        "interval": INHERIT_VALUE,
+        "notify": INHERIT_VALUE,
+        "send_mode": INHERIT_VALUE,
+        "length_limit": INHERIT_VALUE,
+        "display_author": INHERIT_VALUE,
+        "display_via": INHERIT_VALUE,
+        "display_title": INHERIT_VALUE,
+        "display_entry_tags": INHERIT_VALUE,
+        "style": INHERIT_VALUE,
+        "display_media": INHERIT_VALUE,
+    }
+    for field, expected in expected_options.items():
+        assert getattr(sub, field) == expected
+        assert getattr(entity, field) == expected
+
+    assert sub.state == STATE_ENABLED
+    assert entity.state == STATE_ENABLED
+    assert sub.handlers_mode == HANDLERS_MODE_INHERIT
+    assert entity.handlers_mode == HANDLERS_MODE_INHERIT
     assert sub.title == ""
-    assert sub.handlers == "[]"
+    assert entity.title == ""
+    assert sub.tags == ""
+    assert entity.tags == ""
+    assert sub.handlers == handlers_json([])
+    assert entity.handlers == []
+    assert sub.created_at is not None
+    assert sub.updated_at is not None
+    assert entity.created_at is not None
+    assert entity.updated_at is not None
     await engine.dispose()
 
 

--- a/tests/unit/infrastructure/test_database_manager.py
+++ b/tests/unit/infrastructure/test_database_manager.py
@@ -11,6 +11,9 @@ from astrbot_plugin_rsshub.src.infrastructure.persistence.migrations import (
     ensure_push_history_schema,
 )
 from astrbot_plugin_rsshub.src.infrastructure.persistence.models import SubORM
+from astrbot_plugin_rsshub.src.infrastructure.persistence.subscription_repository_impl import (
+    SubscriptionRepositoryImpl,
+)
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -191,25 +194,25 @@ async def test_ensure_profile_schema_allows_current_sub_orm_reads():
             """
             CREATE TABLE rsshub_sub (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                state INTEGER NOT NULL DEFAULT 1,
+                state INTEGER,
                 user_id VARCHAR NOT NULL,
                 feed_id INTEGER NOT NULL,
-                title VARCHAR NOT NULL DEFAULT '',
-                tags VARCHAR NOT NULL DEFAULT '',
+                title VARCHAR,
+                tags VARCHAR,
                 target_session VARCHAR,
                 platform_name VARCHAR,
-                interval INTEGER NOT NULL DEFAULT -100,
+                interval INTEGER,
                 next_check_time DATETIME,
-                notify INTEGER NOT NULL DEFAULT -100,
-                send_mode INTEGER NOT NULL DEFAULT -100,
-                length_limit INTEGER NOT NULL DEFAULT -100,
-                display_author INTEGER NOT NULL DEFAULT -100,
-                display_via INTEGER NOT NULL DEFAULT -100,
-                display_title INTEGER NOT NULL DEFAULT -100,
-                display_entry_tags INTEGER NOT NULL DEFAULT -100,
-                style INTEGER NOT NULL DEFAULT -100,
-                display_media INTEGER NOT NULL DEFAULT -100,
-                handlers TEXT NOT NULL DEFAULT '[]',
+                notify INTEGER,
+                send_mode INTEGER,
+                length_limit INTEGER,
+                display_author INTEGER,
+                display_via INTEGER,
+                display_title INTEGER,
+                display_entry_tags INTEGER,
+                style INTEGER,
+                display_media INTEGER,
+                handlers TEXT,
                 created_at DATETIME,
                 updated_at DATETIME
             )
@@ -222,7 +225,7 @@ async def test_ensure_profile_schema_allows_current_sub_orm_reads():
         await conn.exec_driver_sql(
             """
             INSERT INTO rsshub_sub (id, user_id, feed_id, title, handlers)
-            VALUES (1, 'u1', 1, 'Sub', '[]')
+            VALUES (1, 'u1', 1, NULL, NULL)
             """
         )
 
@@ -233,7 +236,11 @@ async def test_ensure_profile_schema_allows_current_sub_orm_reads():
         sub = await session.get(SubORM, 1)
 
     assert sub is not None
+    assert SubscriptionRepositoryImpl._to_entity(sub).interval == -100
     assert sub.handlers_mode == "inherit"
+    assert sub.interval == -100
+    assert sub.title == ""
+    assert sub.handlers == "[]"
     await engine.dispose()
 
 


### PR DESCRIPTION
## Summary
- Extend v2 profile schema self-heal to normalize legacy NULL option values.
- Convert subscription/user NULL runtime option fields to current inheritance defaults before repositories build domain entities.
- Cover the dashboard failure path by converting a legacy SubORM row through SubscriptionRepositoryImpl._to_entity.

## Tests
- uv run ruff check src/infrastructure/persistence/migrations/migration_runner.py tests/unit/infrastructure/test_database_manager.py
- uv run pytest tests/unit/infrastructure/test_database_manager.py -q

## Summary by Sourcery

在执行架构自修复（schema self-healing）期间，规范化用户表和订阅表中遗留的 `NULL` 配置档（profile）选项值，并验证仓储层实体转换是否正确处理这些情况。

Bug 修复：
- 为 `rsshub_user` 中的 `NULL` 配置字段回填合适的默认值和继承值，防止在运行时解析配置档时出现问题。
- 为 `rsshub_sub` 中的 `NULL` 配置字段（包括 `handlers_mode` 和时间戳）回填数据，确保订阅行为与当前基于继承的默认值保持一致。

测试：
- 扩展数据库管理器测试，用于覆盖遗留的、在 `rsshub_sub` 中包含 `NULL` 配置字段的行的迁移场景，并确保 ORM 和仓储层转换时使用规范化后的默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize legacy NULL profile option values in user and subscription tables during schema self-healing and verify repository entity conversion handles these cases.

Bug Fixes:
- Backfill NULL configuration fields in rsshub_user with appropriate default and inherited values to prevent runtime profile resolution issues.
- Backfill NULL configuration fields in rsshub_sub, including handlers_mode and timestamps, to ensure subscriptions align with current inheritance-based defaults.

Tests:
- Extend database manager tests to cover migration of legacy rsshub_sub rows with NULL profile fields and ensure ORM and repository conversions use normalized defaults.

</details>