### PR TITLE
fix: prepare v2.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1] - 2026-05-23
+
+### Fixed
+
+- 修复 Plugin Pages 默认订阅设置保存时，前端 reactive payload 直接传入 AstrBot bridge 导致 `postMessage` 无法克隆并保存失败的问题。
+- 修复媒体下载失败后在重试或重复推送场景下短时间反复请求同一 URL、持续刷 WARN 日志的问题；新增短 TTL 失败缓存，近期失败的媒体会快速失败并保留原有发送降级语义。
+
 ## [2.0.0] - 2026-05-22
 
 ### Added

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_rsshub
 display_name: RSS订阅
 desc: 多平台RSS订阅推送插件，支持失败队列重试、多BOT去重、平台数据共享、智能发送策略，LLM工具调用，让你的BOT成为信息聚合中心。
-version: v2.0.0
+version: v2.0.1
 author: FlanChanXwO
 repo: https://github.com/FlanChanXwO/astrbot_plugin_rsshub

--- a/pages/dashboard/js/api.js
+++ b/pages/dashboard/js/api.js
@@ -20,6 +20,13 @@ function buildDirectApiUrl(path, params = {}) {
   return url;
 }
 
+function toBridgePayload(value) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
 export async function ready() {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const bridge = getBridge();
@@ -41,13 +48,13 @@ async function handleResponse(result) {
 
 async function apiGet(path, params = {}) {
   const bridge = requireBridge();
-  const result = await bridge.apiGet(path, params);
+  const result = await bridge.apiGet(path, toBridgePayload(params));
   return await handleResponse(result);
 }
 
 async function apiPost(path, payload = {}) {
   const bridge = requireBridge();
-  const result = await bridge.apiPost(path, payload);
+  const result = await bridge.apiPost(path, toBridgePayload(payload));
   return await handleResponse(result);
 }
 

--- a/pages/dashboard/js/api.js
+++ b/pages/dashboard/js/api.js
@@ -24,7 +24,35 @@ function toBridgePayload(value) {
   if (value === undefined || value === null) {
     return value;
   }
-  return JSON.parse(JSON.stringify(value));
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch (_error) {
+      // Fall back to plain objects for reactive or otherwise non-cloneable values.
+    }
+  }
+  return cloneBridgeValue(value, new WeakSet());
+}
+
+function cloneBridgeValue(value, seen) {
+  if (value === undefined || value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    throw new Error('Bridge payload contains circular references');
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const cloned = value.map((item) => cloneBridgeValue(item, seen));
+    seen.delete(value);
+    return cloned;
+  }
+  const cloned = {};
+  for (const [key, item] of Object.entries(value)) {
+    cloned[key] = cloneBridgeValue(item, seen);
+  }
+  seen.delete(value);
+  return cloned;
 }
 
 export async function ready() {

--- a/src/infrastructure/media/media_downloader.py
+++ b/src/infrastructure/media/media_downloader.py
@@ -29,6 +29,7 @@ class MediaDownloader:
 
     _CACHE_TTL_SECONDS: int = 15 * 60
     _FAILURE_CACHE_TTL_SECONDS: int = 5 * 60
+    _FAILURE_CACHE_MAX_ENTRIES: int = 1024
     _CACHE_GC_INTERVAL_SECONDS: int = 5 * 60
     _CACHE_GC_GRACE_SECONDS: int = 10 * 60
     _CACHE_MEDIA_SUFFIXES: tuple[str, ...] = (
@@ -177,11 +178,37 @@ class MediaDownloader:
         return hashlib.sha256(url.encode("utf-8")).hexdigest()
 
     @classmethod
-    def _failure_cache_key(cls, url: str, proxy: str) -> str:
+    def _failure_cache_key(cls, url: str, proxy: str | None) -> str:
         return hashlib.sha256(f"{url}\n{proxy or ''}".encode()).hexdigest()
 
     @classmethod
-    def _read_failure_cache(cls, url: str, proxy: str) -> str | None:
+    def _prune_failure_cache(cls) -> None:
+        if not cls._failure_cache:
+            return
+
+        now = time.time()
+        expired_keys = [
+            key
+            for key, (expire_ts, _detail) in cls._failure_cache.items()
+            if expire_ts < now
+        ]
+        for key in expired_keys:
+            cls._failure_cache.pop(key, None)
+
+        max_entries = cls._FAILURE_CACHE_MAX_ENTRIES
+        if max_entries <= 0 or len(cls._failure_cache) <= max_entries:
+            return
+
+        sorted_items = sorted(
+            cls._failure_cache.items(),
+            key=lambda item: item[1][0],
+        )
+        for key, _value in sorted_items[: len(cls._failure_cache) - max_entries]:
+            cls._failure_cache.pop(key, None)
+
+    @classmethod
+    def _read_failure_cache(cls, url: str, proxy: str | None) -> str | None:
+        cls._prune_failure_cache()
         key = cls._failure_cache_key(url, proxy)
         cached = cls._failure_cache.get(key)
         if cached is None:
@@ -193,15 +220,17 @@ class MediaDownloader:
         return detail
 
     @classmethod
-    def _write_failure_cache(cls, url: str, proxy: str, detail: str) -> None:
+    def _write_failure_cache(cls, url: str, proxy: str | None, detail: str) -> None:
+        cls._prune_failure_cache()
         key = cls._failure_cache_key(url, proxy)
         cls._failure_cache[key] = (
             time.time() + cls._FAILURE_CACHE_TTL_SECONDS,
             detail[:300],
         )
+        cls._prune_failure_cache()
 
     @classmethod
-    def _clear_failure_cache(cls, url: str, proxy: str) -> None:
+    def _clear_failure_cache(cls, url: str, proxy: str | None) -> None:
         cls._failure_cache.pop(cls._failure_cache_key(url, proxy), None)
 
     def _cache_file_path(self, url: str, suffix: str | None = None) -> Path:

--- a/src/infrastructure/media/media_downloader.py
+++ b/src/infrastructure/media/media_downloader.py
@@ -28,6 +28,7 @@ class MediaDownloader:
     """媒体下载器，支持缓存管理和格式转换。"""
 
     _CACHE_TTL_SECONDS: int = 15 * 60
+    _FAILURE_CACHE_TTL_SECONDS: int = 5 * 60
     _CACHE_GC_INTERVAL_SECONDS: int = 5 * 60
     _CACHE_GC_GRACE_SECONDS: int = 10 * 60
     _CACHE_MEDIA_SUFFIXES: tuple[str, ...] = (
@@ -41,6 +42,7 @@ class MediaDownloader:
         ".ogg",
         ".bin",
     )
+    _failure_cache: dict[str, tuple[float, str]] = {}
 
     def __init__(self, cache_dir: Path | None = None) -> None:
         if cache_dir is None:
@@ -173,6 +175,34 @@ class MediaDownloader:
 
     def _cache_file_prefix(self, url: str) -> str:
         return hashlib.sha256(url.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _failure_cache_key(cls, url: str, proxy: str) -> str:
+        return hashlib.sha256(f"{url}\n{proxy or ''}".encode()).hexdigest()
+
+    @classmethod
+    def _read_failure_cache(cls, url: str, proxy: str) -> str | None:
+        key = cls._failure_cache_key(url, proxy)
+        cached = cls._failure_cache.get(key)
+        if cached is None:
+            return None
+        expire_ts, detail = cached
+        if expire_ts < time.time():
+            cls._failure_cache.pop(key, None)
+            return None
+        return detail
+
+    @classmethod
+    def _write_failure_cache(cls, url: str, proxy: str, detail: str) -> None:
+        key = cls._failure_cache_key(url, proxy)
+        cls._failure_cache[key] = (
+            time.time() + cls._FAILURE_CACHE_TTL_SECONDS,
+            detail[:300],
+        )
+
+    @classmethod
+    def _clear_failure_cache(cls, url: str, proxy: str) -> None:
+        cls._failure_cache.pop(cls._failure_cache_key(url, proxy), None)
 
     def _cache_file_path(self, url: str, suffix: str | None = None) -> Path:
         digest = self._cache_file_prefix(url)
@@ -452,9 +482,22 @@ class MediaDownloader:
 
         is_m3u8 = self._guess_suffix(url) == ".m3u8"
         if is_m3u8:
-            return await self._download_m3u8_to_cache(
-                url=url, proxy=proxy, m3u8_timeout=m3u8_timeout
-            )
+            cache_url = f"{url}#mp4"
+            cached_failure = self._read_failure_cache(cache_url, proxy)
+            if cached_failure is not None:
+                raise RuntimeError(
+                    f"recent media download failure cached: url={url}, "
+                    f"last_error={cached_failure}"
+                )
+            try:
+                path = await self._download_m3u8_to_cache(
+                    url=url, proxy=proxy, m3u8_timeout=m3u8_timeout
+                )
+            except Exception as ex:
+                self._write_failure_cache(cache_url, proxy, str(ex))
+                raise
+            self._clear_failure_cache(cache_url, proxy)
+            return path
 
         is_video = self._guess_suffix(url) in {
             ".mp4",
@@ -477,6 +520,12 @@ class MediaDownloader:
                     cached,
                 )
                 return cached
+            cached_failure = self._read_failure_cache(cache_url, proxy)
+            if cached_failure is not None:
+                raise RuntimeError(
+                    f"recent media download failure cached: url={url}, "
+                    f"last_error={cached_failure}"
+                )
 
         logger.debug(
             "Media cache download start: url=%s, timeout_seconds=%s, "
@@ -486,11 +535,15 @@ class MediaDownloader:
             bool(proxy),
             try_convert_gif,
         )
-        tmp_path = await self.download_to_temp(
-            url=url,
-            timeout_seconds=timeout_seconds,
-            proxy=proxy,
-        )
+        try:
+            tmp_path = await self.download_to_temp(
+                url=url,
+                timeout_seconds=timeout_seconds,
+                proxy=proxy,
+            )
+        except Exception as ex:
+            self._write_failure_cache(cache_url, proxy, str(ex))
+            raise
         logger.debug(
             "Media cache download complete: url=%s, tmp=%s, tmp_exists=%s",
             url,
@@ -548,6 +601,7 @@ class MediaDownloader:
                     )
                     return cached
                 written = self._write_cache(cache_url, converted_path)
+                self._clear_failure_cache(cache_url, proxy)
                 logger.debug(
                     "Media cache return new write: url=%s, path=%s",
                     cache_url,

--- a/tests/unit/infrastructure/test_media_downloader.py
+++ b/tests/unit/infrastructure/test_media_downloader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from astrbot_plugin_rsshub.src.infrastructure.media.media_downloader import (
+    MediaDownloader,
+)
+
+
+@pytest.mark.asyncio
+async def test_media_downloader_caches_recent_download_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    MediaDownloader._failure_cache.clear()
+    calls = 0
+
+    async def fail_download(self, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("origin status=523")
+
+    monkeypatch.setattr(MediaDownloader, "download_to_temp", fail_download)
+
+    first = MediaDownloader(cache_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="origin status=523"):
+        await first.get_or_download(url="https://example.com/a.png")
+
+    second = MediaDownloader(cache_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="recent media download failure cached"):
+        await second.get_or_download(url="https://example.com/a.png")
+
+    assert calls == 1
+    MediaDownloader._failure_cache.clear()

--- a/tests/unit/infrastructure/test_media_downloader.py
+++ b/tests/unit/infrastructure/test_media_downloader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -33,3 +34,30 @@ async def test_media_downloader_caches_recent_download_failures(
 
     assert calls == 1
     MediaDownloader._failure_cache.clear()
+
+
+def test_media_downloader_failure_cache_prunes_expired_and_oldest_entries():
+    MediaDownloader._failure_cache.clear()
+    original_max_entries = MediaDownloader._FAILURE_CACHE_MAX_ENTRIES
+    MediaDownloader._FAILURE_CACHE_MAX_ENTRIES = 2
+    now = time.time()
+
+    try:
+        MediaDownloader._failure_cache.update(
+            {
+                "expired": (now - 1, "expired"),
+                "oldest": (now + 10, "oldest"),
+                "middle": (now + 20, "middle"),
+                "newest": (now + 30, "newest"),
+            }
+        )
+
+        MediaDownloader._prune_failure_cache()
+
+        assert MediaDownloader._failure_cache == {
+            "middle": (now + 20, "middle"),
+            "newest": (now + 30, "newest"),
+        }
+    finally:
+        MediaDownloader._FAILURE_CACHE_MAX_ENTRIES = original_max_entries
+        MediaDownloader._failure_cache.clear()


### PR DESCRIPTION
修复 v2.0.0 发现的两个回归问题：

### Modifications / 改动点

- 修复媒体下载失败后，重试或重复推送场景下短时间内反复请求同一 URL、持续刷 WARN 日志的问题；新增短 TTL 失败缓存，近期失败的媒体会快速失败并保留原有发送降级语义。
- 修复 Plugin Pages 默认订阅设置保存时，前端 reactive payload 直接传入 AstrBot bridge 导致 `postMessage` 无法克隆并保存失败的问题。
- 升级插件版本到 `v2.0.1`，并补充 `CHANGELOG.md` 的 2.0.1 修复记录。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
$ node --check pages/dashboard/js/api.js
```

```text
$ uv run ruff check src/infrastructure/media/media_downloader.py tests/unit/infrastructure/test_media_downloader.py
All checks passed!
```

```text
$ uv run pytest tests/unit/infrastructure/test_media_downloader.py tests/unit/infrastructure/test_base_sender_ffmpeg.py -q
....                                                                     [100%]
4 passed, 8 warnings in 0.24s
```

---

### Verification Steps / 验证步骤

```powershell
node --check pages/dashboard/js/api.js
uv run ruff check src/infrastructure/media/media_downloader.py tests/unit/infrastructure/test_media_downloader.py
uv run pytest tests/unit/infrastructure/test_media_downloader.py tests/unit/infrastructure/test_base_sender_ffmpeg.py -q
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed them with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

- [x] 📘 I have read and followed `CONTRIBUTE.md`.
  / 我已阅读并遵守 `CONTRIBUTE.md` 规范。

## Summary by Sourcery

在 2.0.1 发布前修复发现的回归问题：通过为失败的媒体下载添加短期缓存，并修复插件页面（Plugin Pages）桥接负载的克隆问题，然后更新插件元数据和变更日志到 v2.0.1。

Bug 修复：
- 为媒体下载添加短 TTL 的失败缓存，使最近失败的 URL 能被快速拒绝，而不是被反复重试并持续记录警告日志。
- 确保 Plugin Pages API 调用通过 AstrBot bridge 发送可克隆的普通负载，从而能够可靠地保存默认订阅设置。

增强：
- 为媒体下载器的“最近失败缓存”行为增加单元测试覆盖。

文档：
- 在变更日志中记录 2.0.1 的修复内容。

测试：
- 增加单元测试，验证最近的媒体下载失败会被缓存，并阻止重复的下载尝试。

杂务（Chores）：
- 将插件版本元数据更新到 v2.0.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Patch regressions found before the 2.0.1 release by adding short‑lived caching for failed media downloads and fixing Plugin Pages bridge payload cloning, then bumping plugin metadata and changelog for v2.0.1.

Bug Fixes:
- Add a short‑TTL failure cache for media downloads so recently failed URLs are rejected quickly instead of being repeatedly retried and logging warnings.
- Ensure Plugin Pages API calls send a plain, clonable payload through the AstrBot bridge so default subscription settings can be saved reliably.

Enhancements:
- Add unit coverage for the media downloader’s recent‑failure caching behavior.

Documentation:
- Document the 2.0.1 fixes in the changelog.

Tests:
- Introduce a unit test verifying that recent media download failures are cached and prevent repeated download attempts.

Chores:
- Bump plugin version metadata to v2.0.1.

</details>