### PR TITLE
fix(kb): reconcile route knowledge manifest

### DIFF
--- a/docs/project/knowledge.md
+++ b/docs/project/knowledge.md
@@ -109,10 +109,10 @@ source 提供 `metadata.json`，包含：
 3. 删除 `deleted`
 4. 下载并上传 `added + updated`
 5. 对账修复 `reconciled`：补回 local manifest 中缺失的文件记录
-6. 增量保存本地 manifest
+6. 同步结束时统一保存本地 manifest
 
 每一步都会更新任务状态。
-每成功上传或删除一个文档后立即增量更新 local manifest，即使中途失败也不丢失已完成的进度。
+local manifest 只记录本次同步中已确认删除、成功上传或对账修复的结果；上传失败的文档不会写入已同步快照。
 
 ## 为什么需要后台 task status
 

--- a/docs/project/knowledge.md
+++ b/docs/project/knowledge.md
@@ -28,9 +28,13 @@ flowchart TD
   A["启动同步任务"] --> B["获取 source manifest"]
   B --> C["读取本地 managed manifest"]
   C --> D["按 path + sha256 生成 sync plan"]
+  C --> C2["对账 KB 已有文档"]
+  C2 --> D
   D --> E{"计划分类"}
   E -->|"deleted"| F["删除远端旧文档"]
   E -->|"added / updated"| G["下载源文件"]
+  E -->|"reconciled"| G2["修复 local manifest 记录，无需重新下载"]
+  G2 --> J
   G --> H["上传到 AstrBot KB"]
   F --> I["更新任务进度"]
   H --> I
@@ -71,14 +75,15 @@ source 提供 `metadata.json`，包含：
 
 ### 3. build sync plan
 
-`RouteKnowledgeSyncPlan` 分成四类：
+`RouteKnowledgeSyncPlan` 分成五类：
 
 - added
 - updated
 - deleted
 - unchanged
+- reconciled（对账修复）
 
-判断依据主要是 `path + sha256`。
+判断依据是三路归并：source manifest（远端真值）、local manifest（上次同步快照）、KB 实际已有文档。
 
 也就是说：
 
@@ -86,10 +91,12 @@ source 提供 `metadata.json`，包含：
 - `path` 存在但 `sha256` 变化 -> `updated`
 - 本地有但远端没有 -> `deleted`
 - `path` 和 `sha256` 都一致 -> `unchanged`
+- `path` 在 KB 中存在但 local manifest 缺记录或 sha 不一致 -> `reconciled`
 
 这样做的原因是：
 
 - 能避免全量重传
+- 插件重载后 local manifest 丢失时，KB 对账能跳过已上传的文档
 - 能明确删除远端不存在的旧文档
 - 能把同步任务进度做成可解释的计划
 
@@ -98,11 +105,14 @@ source 提供 `metadata.json`，包含：
 执行顺序大致是：
 
 1. 确认 KB 存在
-2. 删除 `deleted`
-3. 下载并上传 `added + updated`
-4. 保存本地 manifest
+2. 对账 KB 已有文档列表
+3. 删除 `deleted`
+4. 下载并上传 `added + updated`
+5. 对账修复 `reconciled`：补回 local manifest 中缺失的文件记录
+6. 增量保存本地 manifest
 
 每一步都会更新任务状态。
+每成功上传或删除一个文档后立即增量更新 local manifest，即使中途失败也不丢失已完成的进度。
 
 ## 为什么需要后台 task status
 

--- a/src/application/services/route_knowledge_service.py
+++ b/src/application/services/route_knowledge_service.py
@@ -293,6 +293,7 @@ class RouteKnowledgeSyncService:
                             await self._repository.delete_document(old_doc_id)
                         await self._repository.upload_document(document)
                         uploaded_count += 1
+                        # 仅在上传成功后更新 manifest 快照，避免失败文档被误记为已同步。
                         files_map[file.path] = file.sha256
                     except Exception as exc:
                         skipped_count += 1
@@ -450,12 +451,13 @@ def build_sync_plan(
             # KB 有文档、local manifest 缺记录——重载后典型场景，对账修复
             reconciled.append(file)
         elif in_kb and local_sha != file.sha256:
-            # KB 有文档但 sha 与 source 不一致，对账标记（不强制重下载）
-            logger.warning(
-                "Routes KB 对账: %s KB sha=%s 与 source sha=%s 不一致，"
+            # KB 有文档，但 local manifest 记录的 sha 与当前 source 不一致。
+            logger.info(
+                "Routes KB 对账: %s local manifest 记录的 sha=%s "
+                "与当前 source sha=%s 不一致（KB 中已存在文档），"
                 "标记 reconciled 但未重新下载",
                 path,
-                local_sha or "(无记录)",
+                local_sha or "(local manifest 无记录)",
                 file.sha256,
             )
             reconciled.append(file)

--- a/src/application/services/route_knowledge_service.py
+++ b/src/application/services/route_knowledge_service.py
@@ -27,12 +27,13 @@ logger = get_logger()
 
 @dataclass(frozen=True)
 class RouteKnowledgeSyncPlan:
-    """Diff between source manifest and local managed manifest."""
+    """Diff between source manifest, local managed manifest and KB actual state."""
 
     added: tuple[RouteKnowledgeFile, ...] = field(default_factory=tuple)
     updated: tuple[RouteKnowledgeFile, ...] = field(default_factory=tuple)
     deleted: tuple[str, ...] = field(default_factory=tuple)
     unchanged: tuple[RouteKnowledgeFile, ...] = field(default_factory=tuple)
+    reconciled: tuple[RouteKnowledgeFile, ...] = field(default_factory=tuple)
 
     @property
     def changed_count(self) -> int:
@@ -54,6 +55,7 @@ class RouteKnowledgeTaskStatus:
     updated: int = 0
     deleted: int = 0
     unchanged: int = 0
+    reconciled: int = 0
     skipped: int = 0
     processed: int = 0
     total: int = 0
@@ -86,6 +88,7 @@ class RouteKnowledgeSyncResult:
     uploaded: int = 0
     deleted: int = 0
     skipped: int = 0
+    reconciled: int = 0
     kb_id: str = ""
 
 
@@ -193,15 +196,24 @@ class RouteKnowledgeSyncService:
                     len(source_manifest.files),
                 )
                 local_manifest = self._load_local_manifest()
-                plan = build_sync_plan(source_manifest, local_manifest)
+                # 对账 KB 已有文档，避免重载后从 0 重新下载
+                kb_docs = await self._repository.list_documents()
+                kb_doc_names = {doc.doc_name for doc in kb_docs}
+                plan = build_sync_plan(
+                    source_manifest,
+                    local_manifest,
+                    kb_doc_names,
+                )
+                # reconciled 文档无需下载/上传，但仍需修复 local manifest
                 total = len(plan.added) + len(plan.updated) + len(plan.deleted)
                 logger.info(
-                    "Routes KB 同步计划: task_id=%s added=%d updated=%d deleted=%d unchanged=%d total=%d",
+                    "Routes KB 同步计划: task_id=%s added=%d updated=%d deleted=%d unchanged=%d reconciled=%d total=%d",
                     effective_task_id,
                     len(plan.added),
                     len(plan.updated),
                     len(plan.deleted),
                     len(plan.unchanged),
+                    len(plan.reconciled),
                     total,
                 )
                 self._task_status = _replace_task(
@@ -211,18 +223,21 @@ class RouteKnowledgeSyncService:
                     updated=len(plan.updated),
                     deleted=len(plan.deleted),
                     unchanged=len(plan.unchanged),
+                    reconciled=len(plan.reconciled),
                     skipped=0,
                     total=total,
                 )
 
-                docs_by_name = {
-                    doc.doc_name: doc.doc_id
-                    for doc in await self._repository.list_documents()
-                }
+                # 复用对账阶段已获取的 KB 文档列表
+                docs_by_name = {doc.doc_name: doc.doc_id for doc in kb_docs}
                 uploaded_count = 0
                 deleted_count = 0
                 skipped_count = 0
+                reconciled_count = 0
                 processed = 0
+
+                # 在内存中维护 files_map，sync 结束后一次性落盘
+                files_map = _local_files_map(local_manifest)
 
                 for path in plan.deleted:
                     doc_name = managed_doc_name(path)
@@ -243,6 +258,7 @@ class RouteKnowledgeSyncService:
                     if doc_id:
                         await self._repository.delete_document(doc_id)
                         deleted_count += 1
+                        files_map.pop(path, None)
                     processed += 1
                     self._task_status = _replace_task(
                         self._task_status, processed=processed
@@ -277,6 +293,7 @@ class RouteKnowledgeSyncService:
                             await self._repository.delete_document(old_doc_id)
                         await self._repository.upload_document(document)
                         uploaded_count += 1
+                        files_map[file.path] = file.sha256
                     except Exception as exc:
                         skipped_count += 1
                         logger.exception(
@@ -296,21 +313,29 @@ class RouteKnowledgeSyncService:
                         self._task_status, processed=processed
                     )
 
-                self._write_local_manifest(source_manifest)
+                # reconciled 文档已在 KB 但 local manifest 丢失了它们的记录，补回
+                for file in plan.reconciled:
+                    files_map[file.path] = file.sha256
+                    reconciled_count += 1
+
+                # 一次性将内存中的 files_map 与元数据写入 local manifest
+                self._flush_local_manifest(files_map, source_manifest)
                 message = (
                     "Routes KB 同步完成: "
                     f"新增 {len(plan.added)}, 更新 {len(plan.updated)}, "
-                    f"删除 {deleted_count}, 跳过 {skipped_count}, 未变更 {len(plan.unchanged)}"
+                    f"删除 {deleted_count}, 跳过 {skipped_count}, "
+                    f"对账修复 {reconciled_count}, 未变更 {len(plan.unchanged)}"
                 )
                 finished_at = _now_iso()
                 logger.info(
-                    "Routes KB 同步完成: task_id=%s kb_id=%s 新增=%d 更新=%d 删除=%d 跳过=%d 未变更=%d",
+                    "Routes KB 同步完成: task_id=%s kb_id=%s 新增=%d 更新=%d 删除=%d 跳过=%d 对账=%d 未变更=%d",
                     effective_task_id,
                     kb_id or "-",
                     len(plan.added),
                     len(plan.updated),
                     deleted_count,
                     skipped_count,
+                    reconciled_count,
                     len(plan.unchanged),
                 )
                 self._task_status = _replace_task(
@@ -321,6 +346,7 @@ class RouteKnowledgeSyncService:
                     current_path="",
                     processed=total,
                     skipped=skipped_count,
+                    reconciled=reconciled_count,
                 )
                 return RouteKnowledgeSyncResult(
                     success=True,
@@ -330,6 +356,7 @@ class RouteKnowledgeSyncService:
                     uploaded=uploaded_count,
                     deleted=deleted_count,
                     skipped=skipped_count,
+                    reconciled=reconciled_count,
                     kb_id=kb_id,
                 )
             except Exception as exc:
@@ -363,14 +390,22 @@ class RouteKnowledgeSyncService:
         except Exception:
             return {}
 
-    def _write_local_manifest(self, manifest: RouteKnowledgeManifest) -> None:
+    def _flush_local_manifest(
+        self,
+        files_map: dict[str, str],
+        manifest: RouteKnowledgeManifest,
+    ) -> None:
+        """一次性将内存中的 files_map 与元数据写入 local manifest。"""
+        files_list = [
+            {"path": p, "sha256": sha} for p, sha in sorted(files_map.items())
+        ]
         self._state_dir.mkdir(parents=True, exist_ok=True)
         payload = {
             "version": manifest.version,
             "generated_at": manifest.generated_at,
             "source": manifest.source,
             "last_sync_at": _now_iso(),
-            "files": [asdict(file) for file in manifest.files],
+            "files": files_list,
         }
         self._manifest_path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2),
@@ -381,23 +416,59 @@ class RouteKnowledgeSyncService:
 def build_sync_plan(
     source_manifest: RouteKnowledgeManifest,
     local_manifest: dict[str, Any],
+    kb_doc_names: set[str] | None = None,
 ) -> RouteKnowledgeSyncPlan:
-    """Build an incremental sync plan by comparing path + sha256."""
+    """Build an incremental sync plan by comparing path + sha256.
+
+    三路归并：source manifest（远端真值）、local manifest（上次同步快照）、
+    kb_doc_names（KB 中实际存在的文档名集合）。
+    当 local manifest 缺失或过期时，KB 对账能把已上传的文档从 added 降级为
+    reconciled，避免重载插件后从 0 重新下载。
+    """
     source_files = {file.path: file for file in source_manifest.files}
     local_files = _local_files_map(local_manifest)
+    # KB 中已有文档的相对路径集合（去掉 MANAGED_DOC_PREFIX）
+    kb_paths: set[str] = set()
+    if kb_doc_names:
+        prefix = MANAGED_DOC_PREFIX
+        for name in kb_doc_names:
+            if name.startswith(prefix):
+                kb_paths.add(name[len(prefix) :].lstrip("/"))
 
     added: list[RouteKnowledgeFile] = []
     updated: list[RouteKnowledgeFile] = []
     unchanged: list[RouteKnowledgeFile] = []
+    reconciled: list[RouteKnowledgeFile] = []
 
     for path, file in source_files.items():
         local_sha = local_files.get(path)
-        if local_sha is None:
-            added.append(file)
-        elif local_sha != file.sha256:
-            updated.append(file)
-        else:
+        in_kb = path in kb_paths
+        if local_sha is not None and local_sha == file.sha256:
+            # local manifest 与 source 一致：无需任何操作
             unchanged.append(file)
+        elif in_kb and local_sha is None:
+            # KB 有文档、local manifest 缺记录——重载后典型场景，对账修复
+            reconciled.append(file)
+        elif in_kb and local_sha != file.sha256:
+            # KB 有文档但 sha 与 source 不一致，对账标记（不强制重下载）
+            logger.warning(
+                "Routes KB 对账: %s KB sha=%s 与 source sha=%s 不一致，"
+                "标记 reconciled 但未重新下载",
+                path,
+                local_sha or "(无记录)",
+                file.sha256,
+            )
+            reconciled.append(file)
+        elif not in_kb and local_sha is not None and local_sha != file.sha256:
+            # 不在 KB 但 local sha 过期——需要更新
+            updated.append(file)
+        elif not in_kb and local_sha is None:
+            # 不在 KB 且 local 无记录——全新文档
+            added.append(file)
+        else:
+            # 不在 KB，local sha 与 source 一致（但 KB 实际缺失）
+            # local 说已同步但 KB 实际没有，需要补传
+            added.append(file)
 
     deleted = sorted(path for path in local_files if path not in source_files)
     return RouteKnowledgeSyncPlan(
@@ -405,6 +476,7 @@ def build_sync_plan(
         updated=tuple(sorted(updated, key=lambda item: item.path)),
         deleted=tuple(deleted),
         unchanged=tuple(sorted(unchanged, key=lambda item: item.path)),
+        reconciled=tuple(sorted(reconciled, key=lambda item: item.path)),
     )
 
 

--- a/src/interfaces/handlers/route_knowledge.py
+++ b/src/interfaces/handlers/route_knowledge.py
@@ -71,7 +71,7 @@ def handle_rsshub_kb_task(deps: dict) -> dict:
         f"任务 ID: {task.task_id}",
         f"状态: {task.status}",
         f"进度: {task.processed}/{task.total}",
-        f"计划: 新增 {task.added}, 更新 {task.updated}, 删除 {task.deleted}, 跳过 {task.skipped}, 未变更 {task.unchanged}",
+        f"计划: 新增 {task.added}, 更新 {task.updated}, 删除 {task.deleted}, 跳过 {task.skipped}{f', 对账修复 {task.reconciled}' if task.reconciled else ''}, 未变更 {task.unchanged}",
     ]
     if task.current_path:
         lines.append(f"当前文件: {task.current_path}")
@@ -83,4 +83,4 @@ def handle_rsshub_kb_task(deps: dict) -> dict:
 
 
 def _format_task_line(task: RouteKnowledgeTaskStatus) -> str:
-    return f"{task.status} {task.processed}/{task.total} ({task.task_id})"
+    return f"{task.status} {task.processed}/{task.total}{f' 对账={task.reconciled}' if task.reconciled else ''} ({task.task_id})"

--- a/tests/unit/application/test_route_knowledge_service.py
+++ b/tests/unit/application/test_route_knowledge_service.py
@@ -162,9 +162,7 @@ def test_build_sync_plan_reconciles_kb_existing_docs_without_local_manifest():
 def test_build_sync_plan_reconciles_kb_docs_with_stale_local_sha():
     """KB 有文档但 local sha 与 source 不一致——对账修复，不强制重新下载。"""
     source = RouteKnowledgeManifest(
-        files=(
-            RouteKnowledgeFile(path="docs/routes/foo.md", sha256="b2"),
-        )
+        files=(RouteKnowledgeFile(path="docs/routes/foo.md", sha256="b2"),)
     )
     local = {
         "files": [
@@ -332,6 +330,7 @@ async def test_sync_reconciles_kb_existing_docs_on_reload(tmp_path):
     assert managed_doc_name("docs/routes/foo.md") not in repo.uploaded
     # 同步完成后 local manifest 应包含所有文件的记录
     import json
+
     local_data = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
     local_files = {item["path"]: item["sha256"] for item in local_data.get("files", [])}
     assert "docs/routes/new.md" in local_files

--- a/tests/unit/application/test_route_knowledge_service.py
+++ b/tests/unit/application/test_route_knowledge_service.py
@@ -218,6 +218,7 @@ async def test_sync_deletes_then_uploads_changed_documents(tmp_path):
     assert result.success is True
     # foo.md 已在 KB 中但 local sha 过期 → reconciled（对账修复），不重新上传
     assert result.reconciled == 1
+    assert managed_doc_name("docs/routes/foo.md") not in repo.uploaded
     assert managed_doc_name("index/namespaces.md") in repo.uploaded
     # deleted.md 被 source 移除，从 KB 物理删除
     assert deleted_doc_id in repo.deleted

--- a/tests/unit/application/test_route_knowledge_service.py
+++ b/tests/unit/application/test_route_knowledge_service.py
@@ -119,12 +119,66 @@ def test_build_sync_plan_detects_add_update_delete_unchanged():
         ]
     }
 
-    plan = build_sync_plan(source, local)
+    plan = build_sync_plan(source, local, kb_doc_names=None)
 
     assert [item.path for item in plan.added] == ["docs/routes/bar.md"]
     assert [item.path for item in plan.updated] == ["docs/routes/foo.md"]
     assert plan.deleted == ("docs/routes/deleted.md",)
     assert [item.path for item in plan.unchanged] == ["index/namespaces.md"]
+    assert plan.reconciled == ()
+
+
+def test_build_sync_plan_reconciles_kb_existing_docs_without_local_manifest():
+    """KB 中已有文档但 local manifest 丢失——插件重载后典型场景。"""
+    source = RouteKnowledgeManifest(
+        files=(
+            RouteKnowledgeFile(path="index/namespaces.md", sha256="a"),
+            RouteKnowledgeFile(path="docs/routes/foo.md", sha256="b2"),
+            RouteKnowledgeFile(path="docs/routes/new.md", sha256="e"),
+        )
+    )
+    # local manifest 为空（重载后丢失）
+    local: dict = {}
+    # KB 中已有这两个文档
+    kb_doc_names = {
+        managed_doc_name("index/namespaces.md"),
+        managed_doc_name("docs/routes/foo.md"),
+    }
+
+    plan = build_sync_plan(source, local, kb_doc_names=kb_doc_names)
+
+    # KB 已有但 local 缺记录 → reconciled（无需重新下载上传）
+    assert [item.path for item in plan.reconciled] == [
+        "docs/routes/foo.md",
+        "index/namespaces.md",
+    ]
+    # KB 中没有且 local 也没有 → added
+    assert [item.path for item in plan.added] == ["docs/routes/new.md"]
+    assert plan.updated == ()
+    assert plan.deleted == ()
+    assert plan.unchanged == ()
+
+
+def test_build_sync_plan_reconciles_kb_docs_with_stale_local_sha():
+    """KB 有文档但 local sha 与 source 不一致——对账修复，不强制重新下载。"""
+    source = RouteKnowledgeManifest(
+        files=(
+            RouteKnowledgeFile(path="docs/routes/foo.md", sha256="b2"),
+        )
+    )
+    local = {
+        "files": [
+            {"path": "docs/routes/foo.md", "sha256": "old"},
+        ]
+    }
+    kb_doc_names = {managed_doc_name("docs/routes/foo.md")}
+
+    plan = build_sync_plan(source, local, kb_doc_names=kb_doc_names)
+
+    # KB 有文档，local sha 过期但 KB 中实际已有→对账修复
+    assert [item.path for item in plan.reconciled] == ["docs/routes/foo.md"]
+    assert plan.updated == ()
+    assert plan.added == ()
 
 
 @pytest.mark.asyncio
@@ -142,6 +196,13 @@ async def test_sync_deletes_then_uploads_changed_documents(tmp_path):
         managed_doc_name("docs/routes/foo.md"),
         "# Foo v1",
     )
+    # deleted 也在 KB 中，确保可以物理删除
+    deleted_doc_id = "deleted-doc"
+    repo.docs[deleted_doc_id] = _StoredDoc(
+        deleted_doc_id,
+        managed_doc_name("docs/routes/deleted.md"),
+        "# deleted",
+    )
     (tmp_path / "manifest.json").write_text(
         '{"files":[{"path":"docs/routes/foo.md","sha256":"old"},'
         '{"path":"docs/routes/deleted.md","sha256":"gone"}]}',
@@ -157,13 +218,15 @@ async def test_sync_deletes_then_uploads_changed_documents(tmp_path):
     result = await service.sync(task_id="task-1")
 
     assert result.success is True
-    assert old_doc_id in repo.deleted
-    assert managed_doc_name("docs/routes/foo.md") in repo.uploaded
+    # foo.md 已在 KB 中但 local sha 过期 → reconciled（对账修复），不重新上传
+    assert result.reconciled == 1
     assert managed_doc_name("index/namespaces.md") in repo.uploaded
+    # deleted.md 被 source 移除，从 KB 物理删除
+    assert deleted_doc_id in repo.deleted
     status = service.get_task_status()
     assert status.status == "completed"
     assert status.added == 1
-    assert status.updated == 1
+    assert status.reconciled == 1
     assert status.deleted == 1
 
 
@@ -228,3 +291,49 @@ async def test_sync_lock_rejects_parallel_runs(tmp_path):
             await service.sync(task_id="task-2")
     finally:
         service._lock.release()
+
+
+@pytest.mark.asyncio
+async def test_sync_reconciles_kb_existing_docs_on_reload(tmp_path):
+    """插件重载后 local manifest 丢失，但 KB 中已有文档——对账修复，不重复下载。"""
+    source_files = {
+        "index/namespaces.md": "# Namespaces",
+        "docs/routes/foo.md": "# Foo",
+        "docs/routes/new.md": "# New",
+    }
+    source = _FakeSource(source_files)
+    repo = _FakeRepository()
+    # 模拟 KB 中已有这两个文档（重载前上传的）
+    for path in ("index/namespaces.md", "docs/routes/foo.md"):
+        doc_id = f"existing-{path}"
+        repo.docs[doc_id] = _StoredDoc(
+            doc_id,
+            managed_doc_name(path),
+            source_files[path],
+        )
+    # 不写 manifest.json——模拟重载后丢失
+    service = RouteKnowledgeSyncService(
+        settings=RouteKnowledgeSettings(),
+        source=source,
+        repository=repo,
+        state_dir=tmp_path,
+    )
+
+    result = await service.sync(task_id="task-reload")
+
+    assert result.success is True
+    # 已在 KB 的文档不重新上传（对账修复）
+    assert result.reconciled == 2
+    # 只有新文档需要上传
+    assert result.uploaded == 1
+    assert managed_doc_name("docs/routes/new.md") in repo.uploaded
+    # reconciled 的文档不应被下载/上传
+    assert managed_doc_name("index/namespaces.md") not in repo.uploaded
+    assert managed_doc_name("docs/routes/foo.md") not in repo.uploaded
+    # 同步完成后 local manifest 应包含所有文件的记录
+    import json
+    local_data = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    local_files = {item["path"]: item["sha256"] for item in local_data.get("files", [])}
+    assert "docs/routes/new.md" in local_files
+    assert "index/namespaces.md" in local_files
+    assert "docs/routes/foo.md" in local_files


### PR DESCRIPTION
## Summary
- reconcile Routes KB sync against existing KB documents when local manifest is missing or stale
- persist repaired local manifest entries after upload/delete/reconcile
- expose reconciled counts in task status/result and docs

## Tests
- uv run --project /Users/flanchan/Development/SourceCode/GithubProjects/AstrbotPluginDev python -m pytest /tmp/codex-rsshub-knowledge/astrbot_plugin_rsshub/tests/unit/application/test_route_knowledge_service.py -q

## Summary by Sourcery

将路由知识同步与实际的知识库（KB）状态对齐，使缺失或过期的本地清单不会触发不必要的重新下载，并在同步结果和任务状态中暴露对账（reconciliation）相关的指标。

Bug Fixes（缺陷修复）:
- 当知识库中已经包含路由文档但本地清单缺失或过期时，通过与现有的 KB 文档进行对账，防止冗余的下载和上传操作。

Enhancements（功能增强）:
- 扩展同步计划，在已添加（added）、已更新（updated）、已删除（deleted）和未更改（unchanged）项目之外，额外跟踪已对账（reconciled）文档。
- 更新同步逻辑，以复用之前列出的 KB 文档，在操作期间维护内存中的清单映射，并在运行结束时刷新修复后的本地清单。
- 在同步状态、同步结果和任务状态的输出格式中暴露已对账文档的数量，并相应调整日志和面向用户的任务消息。

Documentation（文档）:
- 更新知识同步文档和流程图，以描述 KB 对账流程、新增的已对账类别，以及修订后的同步步骤。

Tests（测试）:
- 增加并调整同步计划和同步服务行为的单元测试，以覆盖对账场景、本地清单修复以及已对账项目的报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reconcile route knowledge synchronization with the actual KB state so that missing or stale local manifests do not trigger unnecessary re-downloads, and expose reconciliation metrics in sync results and task status.

Bug Fixes:
- Prevent redundant downloads and uploads when the KB already contains route documents but the local manifest is missing or out of date by reconciling against existing KB documents.

Enhancements:
- Extend the sync plan to track reconciled documents in addition to added, updated, deleted, and unchanged items.
- Update sync logic to reuse previously listed KB documents, maintain an in-memory manifest map during operations, and flush a repaired local manifest at the end of the run.
- Expose reconciled document counts in sync status, sync results, and task status formatting, and adjust logs and user-facing task messages accordingly.

Documentation:
- Update knowledge synchronization documentation and flow diagrams to describe KB reconciliation, the new reconciled category, and the revised sync steps.

Tests:
- Add and adjust unit tests for sync planning and sync service behavior to cover reconciliation scenarios, local manifest repair, and reporting of reconciled items.

</details>