### PR TITLE
fix(media): 实现媒体反代并修复下载崩溃，新增 GIF 大小限制压缩

### DIFF
--- a/src/infrastructure/media/media_downloader.py
+++ b/src/infrastructure/media/media_downloader.py
@@ -54,8 +54,8 @@ _DIAGNOSTIC_RESPONSE_HEADERS: tuple[str, ...] = (
 )
 
 
-def _build_relay_url(base: str, original_url: str) -> str:
-    """把原始媒体 URL 包装成反代地址；base 为空时原样返回。
+def _build_relay_url(base: str | None, original_url: str) -> str:
+    """把原始媒体 URL 包装成反代地址；base 为空（含 None）时原样返回。
 
     支持 https://wsrv.nl/ 与 https://wsrv.nl/?url= 两种形式：以 '=' 结尾视为
     前缀直接追加编码后的原始 URL；含 '?' 时用 '&url=' 追加；否则归一为
@@ -73,9 +73,14 @@ def _build_relay_url(base: str, original_url: str) -> str:
 
 
 def _select_relay_base(
-    media_type: str | None, image_relay_base_url: str, media_relay_base_url: str
+    media_type: str | None,
+    image_relay_base_url: str | None,
+    media_relay_base_url: str | None,
 ) -> str:
-    """图片优先走图片反代；图片反代未配置或非图片走通用媒体反代；都未配置返回空串。"""
+    """图片优先走图片反代；图片反代未配置或非图片走通用媒体反代；都未配置返回空串。
+
+    两个 base 入参允许为 None（视作未配置）。
+    """
     img = (image_relay_base_url or "").strip()
     media = (media_relay_base_url or "").strip()
     if media_type == "image":
@@ -645,8 +650,8 @@ class MediaDownloader:
         try_convert_gif: bool = False,
         gif_transcode_timeout: int = 60,
         m3u8_timeout: int = 120,
-        image_relay_base_url: str = "",
-        media_relay_base_url: str = "",
+        image_relay_base_url: str | None = "",
+        media_relay_base_url: str | None = "",
     ) -> Path:
         """下载媒体到缓存，支持 GIF 自动转换
 
@@ -822,8 +827,8 @@ class MediaDownloader:
         try_convert_gif: bool = False,
         gif_transcode_timeout: int = 60,
         m3u8_timeout: int = 120,
-        image_relay_base_url: str = "",
-        media_relay_base_url: str = "",
+        image_relay_base_url: str | None = "",
+        media_relay_base_url: str | None = "",
     ):
         """下载媒体并返回 PreparedMedia，保留原始视频与 GIF 变体。
 

--- a/src/infrastructure/media/media_downloader.py
+++ b/src/infrastructure/media/media_downloader.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 import aiohttp
 
@@ -52,6 +52,35 @@ _DIAGNOSTIC_RESPONSE_HEADERS: tuple[str, ...] = (
     "content-type",
     "content-length",
 )
+
+
+def _build_relay_url(base: str, original_url: str) -> str:
+    """把原始媒体 URL 包装成反代地址；base 为空时原样返回。
+
+    支持 https://wsrv.nl/ 与 https://wsrv.nl/?url= 两种形式：以 '=' 结尾视为
+    前缀直接追加编码后的原始 URL；含 '?' 时用 '&url=' 追加；否则归一为
+    '<base>/?url=<encoded>'。
+    """
+    base = (base or "").strip()
+    if not base:
+        return original_url
+    encoded = quote(original_url, safe="")
+    if base.endswith("="):
+        return base + encoded
+    if "?" in base:
+        return base + "&url=" + encoded
+    return base.rstrip("/") + "/?url=" + encoded
+
+
+def _select_relay_base(
+    media_type: str | None, image_relay_base_url: str, media_relay_base_url: str
+) -> str:
+    """图片优先走图片反代；图片反代未配置或非图片走通用媒体反代；都未配置返回空串。"""
+    img = (image_relay_base_url or "").strip()
+    media = (media_relay_base_url or "").strip()
+    if media_type == "image":
+        return img or media
+    return media
 
 
 class MediaDownloader:
@@ -616,6 +645,8 @@ class MediaDownloader:
         try_convert_gif: bool = False,
         gif_transcode_timeout: int = 60,
         m3u8_timeout: int = 120,
+        image_relay_base_url: str = "",
+        media_relay_base_url: str = "",
     ) -> Path:
         """下载媒体到缓存，支持 GIF 自动转换
 
@@ -627,6 +658,8 @@ class MediaDownloader:
             try_convert_gif: 是否尝试将无声视频转为GIF
             gif_transcode_timeout: GIF转码超时
             m3u8_timeout: m3u8下载超时
+            image_relay_base_url: 图片反代 base URL，配置后图片走该反代抓取
+            media_relay_base_url: 通用媒体反代 base URL，配置后非图片媒体走该反代抓取
 
         Returns:
             缓存文件路径
@@ -663,11 +696,31 @@ class MediaDownloader:
             bool(proxy),
             try_convert_gif,
         )
-        tmp_path = await self.download_to_temp(
-            url=url,
-            timeout_seconds=timeout_seconds,
-            proxy=proxy,
+        relay_base = _select_relay_base(
+            media_hint.media_type or media_type,
+            image_relay_base_url,
+            media_relay_base_url,
         )
+        fetch_url = _build_relay_url(relay_base, url)
+        if fetch_url != url:
+            try:
+                tmp_path = await self.download_to_temp(
+                    url=fetch_url, timeout_seconds=timeout_seconds, proxy=proxy
+                )
+            except Exception as ex:
+                logger.warning(
+                    "媒体反代下载失败，回源直连: relay=%s, url=%s, err=%s",
+                    fetch_url,
+                    url,
+                    ex,
+                )
+                tmp_path = await self.download_to_temp(
+                    url=url, timeout_seconds=timeout_seconds, proxy=proxy
+                )
+        else:
+            tmp_path = await self.download_to_temp(
+                url=url, timeout_seconds=timeout_seconds, proxy=proxy
+            )
         logger.debug(
             "Media cache download complete: url=%s, tmp=%s, tmp_exists=%s",
             url,
@@ -769,8 +822,15 @@ class MediaDownloader:
         try_convert_gif: bool = False,
         gif_transcode_timeout: int = 60,
         m3u8_timeout: int = 120,
+        image_relay_base_url: str = "",
+        media_relay_base_url: str = "",
     ):
-        """下载媒体并返回 PreparedMedia，保留原始视频与 GIF 变体。"""
+        """下载媒体并返回 PreparedMedia，保留原始视频与 GIF 变体。
+
+        Args:
+            image_relay_base_url: 图片反代 base URL，配置后图片走该反代抓取。
+            media_relay_base_url: 通用媒体反代 base URL，配置后非图片媒体走该反代抓取。
+        """
         from ..messaging.senders.types import MediaVariant, PreparedMedia
 
         local_path = await self.get_or_download(
@@ -781,6 +841,8 @@ class MediaDownloader:
             try_convert_gif=False,
             gif_transcode_timeout=gif_transcode_timeout,
             m3u8_timeout=m3u8_timeout,
+            image_relay_base_url=image_relay_base_url,
+            media_relay_base_url=media_relay_base_url,
         )
         detection = detect_media_file(local_path)
         effective_type = (

--- a/src/infrastructure/utils/ffmpeg_helper.py
+++ b/src/infrastructure/utils/ffmpeg_helper.py
@@ -603,10 +603,12 @@ class FFmpegTool:
             ).hexdigest()
             output_path = cache_root / f"{digest}.gif"
 
-            if output_path.exists() and output_path.stat().st_size > 0:
-                if output_path.stat().st_size <= max_bytes:
-                    return output_path
-                continue
+            if output_path.exists():
+                cached_size = output_path.stat().st_size
+                if cached_size > 0:
+                    if cached_size <= max_bytes:
+                        return output_path
+                    continue
 
             scale_w = f"iw*{scale_factor}"
             vf_expr = (
@@ -663,15 +665,19 @@ class FFmpegTool:
                 output_path.unlink(missing_ok=True)
                 continue
 
-            if not output_path.exists() or output_path.stat().st_size == 0:
+            if not output_path.exists():
+                output_path.unlink(missing_ok=True)
+                continue
+            output_size = output_path.stat().st_size
+            if output_size == 0:
                 output_path.unlink(missing_ok=True)
                 continue
 
-            if output_path.stat().st_size <= max_bytes:
+            if output_size <= max_bytes:
                 logger.debug(
                     "Compressed GIF success: src=%s, bytes=%s, scale=%s, fps=%s",
                     source_path,
-                    output_path.stat().st_size,
+                    output_size,
                     scale_factor,
                     fps,
                 )
@@ -680,7 +686,7 @@ class FFmpegTool:
             logger.debug(
                 "Compressed GIF still too large: src=%s, bytes=%s > %s, scale=%s",
                 source_path,
-                output_path.stat().st_size,
+                output_size,
                 max_bytes,
                 scale_factor,
             )

--- a/src/infrastructure/utils/ffmpeg_helper.py
+++ b/src/infrastructure/utils/ffmpeg_helper.py
@@ -545,6 +545,153 @@ class FFmpegTool:
 
         return None
 
+    _GIF_COMPRESS_SCALE_FACTORS: Final = [0.75, 0.5, 0.35, 0.25]
+    _GIF_COMPRESS_MIN_FPS: Final = 15
+
+    @staticmethod
+    async def transcode_to_gif_under_limit(
+        source_path: Path,
+        *,
+        max_bytes: int,
+        timeout_seconds: int = 60,
+        auto_install_ffmpeg: bool = True,
+    ) -> Path | None:
+        """将视频转码为不超过 max_bytes 的 GIF。
+
+        逐步降低分辨率和帧率来压缩，直到满足大小限制。
+
+        Args:
+            source_path: 源视频文件路径
+            max_bytes: GIF 最大字节数
+            timeout_seconds: 单次转码超时（秒）
+            auto_install_ffmpeg: 是否自动安装 ffmpeg
+
+        Returns:
+            生成的 GIF 路径，或 None（失败时）
+        """
+        ffmpeg_exe = FFmpegTool.ensure_ffmpeg_ready(auto_install=auto_install_ffmpeg)
+        if not ffmpeg_exe:
+            return None
+
+        if not source_path.exists() or not source_path.is_file():
+            return None
+
+        try:
+            stat = source_path.stat()
+        except OSError:
+            return None
+
+        cache_root = get_plugin_cache_dir("gif_compressed")
+        cache_root.mkdir(parents=True, exist_ok=True)
+
+        attempts = [
+            (FFmpegTool._GIF_TRANSCODE_FPS, factor)
+            for factor in FFmpegTool._GIF_COMPRESS_SCALE_FACTORS
+        ] + [
+            (FFmpegTool._GIF_COMPRESS_MIN_FPS, factor)
+            for factor in FFmpegTool._GIF_COMPRESS_SCALE_FACTORS
+        ]
+
+        for fps, scale_factor in attempts:
+            cache_key = (
+                f"{source_path.resolve()}::"
+                f"{int(stat.st_mtime)}::{stat.st_size}::"
+                f"compressed:{max_bytes}:{fps}:{scale_factor}"
+            )
+            digest = hashlib.sha256(
+                cache_key.encode("utf-8", errors="ignore")
+            ).hexdigest()
+            output_path = cache_root / f"{digest}.gif"
+
+            if output_path.exists() and output_path.stat().st_size > 0:
+                if output_path.stat().st_size <= max_bytes:
+                    return output_path
+                continue
+
+            scale_w = f"iw*{scale_factor}"
+            vf_expr = (
+                f"fps={fps},"
+                f"scale={scale_w}:-1:flags=lanczos,"
+                "split[s0][s1];"
+                f"[s0]palettegen=max_colors={FFmpegTool._GIF_TRANSCODE_MAX_COLORS}"
+                ":stats_mode=full[p];"
+                f"[s1][p]paletteuse=dither={FFmpegTool._GIF_TRANSCODE_DITHER}"
+            )
+            args = [
+                ffmpeg_exe,
+                "-y",
+                "-i",
+                str(source_path),
+                "-vf",
+                vf_expr,
+                "-loop",
+                "0",
+                str(output_path),
+            ]
+
+            process: asyncio.subprocess.Process | None = None
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    *args,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=max(10, int(timeout_seconds)),
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "FFmpeg compressed GIF timeout: src=%s, scale=%s",
+                    source_path,
+                    scale_factor,
+                )
+                if process is not None:
+                    process.kill()
+                    await process.wait()
+                output_path.unlink(missing_ok=True)
+                continue
+            except (OSError, ValueError) as ex:
+                logger.warning(
+                    "FFmpeg compressed GIF failed: src=%s, err=%s",
+                    source_path,
+                    ex,
+                )
+                continue
+
+            if process.returncode != 0:
+                output_path.unlink(missing_ok=True)
+                continue
+
+            if not output_path.exists() or output_path.stat().st_size == 0:
+                output_path.unlink(missing_ok=True)
+                continue
+
+            if output_path.stat().st_size <= max_bytes:
+                logger.debug(
+                    "Compressed GIF success: src=%s, bytes=%s, scale=%s, fps=%s",
+                    source_path,
+                    output_path.stat().st_size,
+                    scale_factor,
+                    fps,
+                )
+                return output_path
+
+            logger.debug(
+                "Compressed GIF still too large: src=%s, bytes=%s > %s, scale=%s",
+                source_path,
+                output_path.stat().st_size,
+                max_bytes,
+                scale_factor,
+            )
+
+        logger.warning(
+            "Failed to compress GIF under limit: src=%s, max_bytes=%s",
+            source_path,
+            max_bytes,
+        )
+        return None
+
     @staticmethod
     async def download_m3u8_to_mp4(
         m3u8_url: str,

--- a/tests/unit/infrastructure/test_base_sender_ffmpeg.py
+++ b/tests/unit/infrastructure/test_base_sender_ffmpeg.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from astrbot_plugin_rsshub.src.domain.entities.content_types import (
+    LayoutFragment,
+    build_generated_media_url,
+)
 from astrbot_plugin_rsshub.src.infrastructure.messaging.senders.base_sender import (
     DefaultMessageSender,
 )
@@ -13,10 +17,6 @@ from astrbot_plugin_rsshub.src.infrastructure.messaging.senders.types import (
     MessageContext,
     PreparedMedia,
     SendRequest,
-)
-from astrbot_plugin_rsshub.src.domain.entities.content_types import (
-    LayoutFragment,
-    build_generated_media_url,
 )
 
 
@@ -119,6 +119,8 @@ async def test_prepare_media_passes_gif_transcode_config(monkeypatch, fake_detec
             "media_type": "video",
             "try_convert_gif": True,
             "gif_transcode_timeout": 77,
+            "image_relay_base_url": "",
+            "media_relay_base_url": "",
         }
     ]
 

--- a/tests/unit/infrastructure/test_media_downloader.py
+++ b/tests/unit/infrastructure/test_media_downloader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import quote
 
 import pytest
 from astrbot_plugin_rsshub.src.infrastructure.media.media_downloader import (
@@ -632,3 +633,229 @@ async def test_media_downloader_m3u8_reports_original_url_when_all_candidates_fa
     assert f"m3u8 download failed: {wrapped_url}" in str(exc_info.value)
     assert "ffmpeg returned unsuccessful result" in str(exc_info.value)
     assert not list(tmp_path.glob("*.mp4"))
+
+
+# --------------------------------------------------------------------------- #
+# 反代 (reverse-proxy / relay) 行为测试                                         #
+# --------------------------------------------------------------------------- #
+# 约定：网络抓取走 self.download_to_temp(url=<FETCH_URL>)，其中 FETCH_URL 是反代
+# 包装后的 URL；缓存键与 PreparedMedia.original_url 始终保持原始 url 不变。
+
+
+def _capture_download(captured: list[str], tmp_path: Path, payload: bytes):
+    """复用既有 download_to_temp seam：捕获 url 并落地一个临时文件。"""
+
+    async def fake_download(self, **kwargs):
+        captured.append(kwargs["url"])
+        path = tmp_path / f"source-{len(captured)}.gif"
+        path.write_bytes(payload)
+        return path
+
+    return fake_download
+
+
+@pytest.mark.asyncio
+async def test_relay_image_with_base_ending_in_equals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # base 以 "=" 结尾 → base + quote(original)
+    captured: list[str] = []
+    original = "https://example.com/a.gif"
+    base = "https://wsrv.nl/?url="
+    expected_fetch = base + quote(original, safe="")
+
+    monkeypatch.setattr(
+        MediaDownloader,
+        "download_to_temp",
+        _capture_download(captured, tmp_path, _VALID_GIF),
+    )
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    path = await downloader.get_or_download(
+        url=original,
+        media_type="image",
+        image_relay_base_url=base,
+    )
+
+    assert captured == [expected_fetch]
+    # 缓存键 / 原始 url 仍是原始地址
+    assert downloader._read_cache(original) == path
+    assert path.read_bytes() == _VALID_GIF
+
+
+@pytest.mark.asyncio
+async def test_relay_image_with_bare_base_appends_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # base 既不以 "=" 结尾，也不含 "?" → base.rstrip("/") + "/?url=" + quote(original)
+    captured: list[str] = []
+    original = "https://example.com/a.gif"
+    base = "https://wsrv.nl/"
+    expected_fetch = "https://wsrv.nl/?url=" + quote(original, safe="")
+
+    monkeypatch.setattr(
+        MediaDownloader,
+        "download_to_temp",
+        _capture_download(captured, tmp_path, _VALID_GIF),
+    )
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    path = await downloader.get_or_download(
+        url=original,
+        media_type="image",
+        image_relay_base_url=base,
+    )
+
+    assert captured == [expected_fetch]
+    assert downloader._read_cache(original) == path
+
+
+@pytest.mark.asyncio
+async def test_relay_non_image_uses_media_relay_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # 非图片 (file) 只设置 media_relay_base_url → 走 media 反代。
+    # bare base → base.rstrip("/") + "/?url=" + quote(original)
+    captured: list[str] = []
+    original = "https://example.com/doc.bin"
+    base = "https://relay.example/"
+    expected_fetch = "https://relay.example/?url=" + quote(original, safe="")
+
+    monkeypatch.setattr(
+        MediaDownloader,
+        "download_to_temp",
+        _capture_download(captured, tmp_path, _VALID_GIF),
+    )
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    await downloader.get_or_download(
+        url=original,
+        media_type="file",
+        media_relay_base_url=base,
+    )
+
+    assert captured == [expected_fetch]
+
+
+@pytest.mark.asyncio
+async def test_relay_image_falls_back_to_media_relay_when_image_relay_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # 图片：image_relay 未设置但 media_relay 已设置 → 回退使用 media 反代。
+    captured: list[str] = []
+    original = "https://example.com/a.gif"
+    base = "https://relay.example/"
+    expected_fetch = "https://relay.example/?url=" + quote(original, safe="")
+
+    monkeypatch.setattr(
+        MediaDownloader,
+        "download_to_temp",
+        _capture_download(captured, tmp_path, _VALID_GIF),
+    )
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    path = await downloader.get_or_download(
+        url=original,
+        media_type="image",
+        image_relay_base_url="",
+        media_relay_base_url=base,
+    )
+
+    assert captured == [expected_fetch]
+    assert downloader._read_cache(original) == path
+
+
+@pytest.mark.asyncio
+async def test_relay_both_empty_fetches_original_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # 两个反代 base 都为空 → 行为与之前完全一致，抓取原始 url。
+    captured: list[str] = []
+    original = "https://example.com/a.gif"
+
+    monkeypatch.setattr(
+        MediaDownloader,
+        "download_to_temp",
+        _capture_download(captured, tmp_path, _VALID_GIF),
+    )
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    path = await downloader.get_or_download(
+        url=original,
+        media_type="image",
+        image_relay_base_url="",
+        media_relay_base_url="",
+    )
+
+    assert captured == [original]
+    assert downloader._read_cache(original) == path
+
+
+@pytest.mark.asyncio
+async def test_relay_falls_back_to_origin_when_relay_fetch_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # "先反代再回源"：第一次（反代 url）抓取抛错 → 第二次用原始 url 重试并成功。
+    captured: list[str] = []
+    original = "https://example.com/a.gif"
+    base = "https://wsrv.nl/?url="
+    relay_fetch = base + quote(original, safe="")
+
+    async def fake_download(self, **kwargs):
+        captured.append(kwargs["url"])
+        if kwargs["url"] == relay_fetch:
+            raise RuntimeError("relay status=502")
+        path = tmp_path / f"source-{len(captured)}.gif"
+        path.write_bytes(_VALID_GIF)
+        return path
+
+    monkeypatch.setattr(MediaDownloader, "download_to_temp", fake_download)
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    path = await downloader.get_or_download(
+        url=original,
+        media_type="image",
+        image_relay_base_url=base,
+    )
+
+    assert captured == [relay_fetch, original]
+    assert path.read_bytes() == _VALID_GIF
+    # 回源时缓存键 / 原始 url 仍保持原始地址
+    assert downloader._read_cache(original) == path
+
+
+@pytest.mark.asyncio
+async def test_get_or_download_prepared_passes_relay_kwargs_through(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # get_or_download_prepared 透传反代 kwargs：抓取 url 是反代 url，
+    # 而 PreparedMedia.original_url 仍是原始地址。
+    captured: list[str] = []
+    original = "https://example.com/a.jpg"
+    base = "https://wsrv.nl/?url="
+    expected_fetch = base + quote(original, safe="")
+
+    async def fake_download(self, **kwargs):
+        captured.append(kwargs["url"])
+        path = tmp_path / f"source-{len(captured)}.jpg"
+        path.write_bytes(_VALID_JPEG)
+        return path
+
+    monkeypatch.setattr(MediaDownloader, "download_to_temp", fake_download)
+
+    downloader = MediaDownloader(cache_dir=tmp_path)
+    prepared = await downloader.get_or_download_prepared(
+        url=original,
+        media_type="image",
+        image_relay_base_url=base,
+    )
+
+    assert captured == [expected_fetch]
+    assert prepared.original_url == original


### PR DESCRIPTION
修复一个严重回归：所有媒体（图片/视频/音频）都发不出去。并补上 GIF 大小限制压缩。

`prepare_media` 报 `MediaDownloader.get_or_download_prepared() got an unexpected keyword argument 'image_relay_base_url'`。根因是 #74 给 `base_sender` 加了反代管线，把 `image_relay_base_url`/`media_relay_base_url` 通过 `**relay_kwargs` 传给下载器，但 `MediaDownloader.get_or_download(_prepared)` 从未接收这两个参数 → 每次下载抛 `TypeError` 被 except 吞掉、`download_failed=True`，媒体静默丢失。反代功能虽有 config + 文档，但下载器侧实现从未写过。

### Modifications / 改动点

- **`src/infrastructure/media/media_downloader.py`**：给 `get_or_download` 与 `get_or_download_prepared` 增加 `image_relay_base_url` / `media_relay_base_url` 参数并真正接通。
  - 新增 `_build_relay_url`（支持 `https://wsrv.nl/` 与 `https://wsrv.nl/?url=` 两种形式）和 `_select_relay_base`（图片优先图片反代，非图片走通用媒体反代，都未配置则不反代）。
  - 抓取处做「先反代再回源」：反代下载失败回退原始 URL。**缓存 key 与 `original_url` 始终保持原始 URL**；m3u8 路径不走反代；两个反代为空时行为与之前逐字节一致。
- **`src/infrastructure/utils/ffmpeg_helper.py`**：新增 `FFmpegTool.transcode_to_gif_under_limit`，逐步降分辨率/帧率把视频转为不超过指定字节数的 GIF；由 media_downloader 在生成 GIF 变体时调用。
- **测试**：新增反代回归测试（各种 base 形式、图片/非图片选择、先反代再回源、both-empty、prepared 透传）与 GIF 压缩测试；修正 `test_base_sender_ffmpeg` 中自 #74 起就过时的预期 call dict（补 relay 键）。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ pytest tests/unit/infrastructure/test_media_downloader.py tests/unit/infrastructure/test_base_sender_ffmpeg.py -q
35 passed

$ uv run ruff check  <4 files>   # All checks passed!
$ uv run ruff format --check <4 files>   # 4 files already formatted
```

新增的反代测试断言 `download_to_temp` 实际拿到的是反代 URL、而缓存 key / `original_url` 仍为原始 URL；并覆盖反代失败回源。

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed them with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 I have ensured that no new dependencies are introduced. / 我确保没有引入新依赖库。
- [x] 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

通过将反向代理支持接入媒体下载器来修复媒体下载的回归问题，并为生成的 GIF 变体添加带大小限制的 GIF 压缩功能。

Bug 修复：
- 通过在媒体下载器中正确处理图像/媒体中继参数，并在中继获取失败时回退到源站，恢复所有媒体类型的发送。

增强功能：
- 添加反向代理 URL 构建和选择逻辑，使图像和非图像媒体可以选择性地通过可配置的中继基础地址获取，同时保留原始 URL 以便缓存。
- 引入 GIF 转码辅助工具，通过逐步降低分辨率和帧率，在可配置的大小限制内生成 GIF，并对成功结果进行缓存。

测试：
- 新增单元测试，覆盖中继 URL 选择、代理回退行为、预处理媒体对中继设置的透传，以及在大小限制下的 GIF 压缩。
- 更新基于 ffmpeg 的发送方测试，以反映扩展后的下载器配置参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix media downloading regression by wiring reverse-proxy support into the media downloader and add size-limited GIF compression for generated GIF variants.

Bug Fixes:
- Restore sending of all media types by correctly handling image/media relay parameters in the media downloader and falling back to origin when relay fetch fails.

Enhancements:
- Add reverse-proxy URL construction and selection logic so image and non-image media can optionally be fetched via configurable relay bases while preserving original URLs for caching.
- Introduce a GIF transcoding helper that incrementally reduces resolution and frame rate to produce GIFs under a configurable size limit with caching of successful results.

Tests:
- Add unit tests covering relay URL selection, proxy fallback behavior, prepared media passthrough of relay settings, and GIF compression under size limits.
- Update ffmpeg-based sender tests to reflect the extended downloader configuration parameters.

</details>