### PR TITLE
fix: improve overview success chart

### DIFF
--- a/pages/dashboard/css/dashboard.css
+++ b/pages/dashboard/css/dashboard.css
@@ -9,10 +9,11 @@
 .overview-chart-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: 16px; margin-top: 16px; }
 .overview-chart-panel { min-width: 0; border: 1px solid #e2e8f0; border-radius: 8px; background: white; padding: 16px; }
 .overview-chart-panel-wide { grid-column: 1 / -1; }
-.overview-chart-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.overview-chart-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
 .overview-chart-head h3 { margin: 0; color: #1b1c1d; font-size: 15px; font-weight: 700; }
-.overview-chart-meta { min-width: 0; color: #94a3b8; font-size: 12px; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.overview-chart-canvas { position: relative; width: 100%; height: 260px; min-width: 0; }
+.overview-chart-meta { min-width: 0; max-width: min(100%, 420px); color: #94a3b8; font-size: 12px; line-height: 1.45; text-align: right; overflow-wrap: anywhere; }
+.overview-chart-canvas { position: relative; width: 100%; height: 280px; min-width: 0; }
+.overview-chart-panel-wide .overview-chart-canvas { height: 340px; }
 .overview-chart-canvas-small { height: 220px; }
 .overview-doughnut-layout { display: grid; grid-template-columns: minmax(190px, 0.8fr) minmax(260px, 1.2fr); gap: 18px; align-items: center; }
 .overview-doughnut-canvas { height: 300px; }
@@ -309,7 +310,8 @@ textarea.select-input { resize: vertical; line-height: 1.5; }
   .overview-chart-panel { padding: 14px; }
   .overview-chart-head { align-items: flex-start; flex-direction: column; gap: 4px; }
   .overview-chart-meta { text-align: left; white-space: normal; }
-  .overview-chart-canvas { height: 240px; }
+  .overview-chart-canvas,
+  .overview-chart-panel-wide .overview-chart-canvas { height: 280px; }
   .overview-doughnut-canvas { height: 260px; }
   .overview-health-summary { grid-template-columns: 1fr; }
   .segmented-control { width: 100%; justify-content: stretch; }

--- a/pages/dashboard/store/modules/charts.js
+++ b/pages/dashboard/store/modules/charts.js
@@ -1,0 +1,101 @@
+export const CHART_COLORS = {
+  orange: '#f59e0b',
+  red: '#ef4444',
+  amber: '#eab308',
+  teal: '#0f766e',
+  blue: '#2563eb',
+  slate: '#64748b',
+  green: '#16a34a',
+};
+
+export function chartTextColor() {
+  return currentTheme() === 'dark' ? '#cbd5e1' : '#475569';
+}
+
+export function chartGridColor() {
+  return currentTheme() === 'dark' ? 'rgba(148, 163, 184, 0.22)' : 'rgba(148, 163, 184, 0.24)';
+}
+
+function currentTheme() {
+  return typeof document === 'undefined' ? 'light' : document.documentElement.dataset.theme;
+}
+
+export function formatBucketLabel(value, unit) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value || '');
+  if (unit === 'hour') {
+    return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:00`;
+  }
+  return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+}
+
+export function percentLabel(value) {
+  if (value === null || value === undefined) return '无终态记录';
+  return `${Math.round(Number(value) * 1000) / 10}%`;
+}
+
+export function buildPushSuccessDataset(points) {
+  return {
+    label: '推送成功率',
+    data: points.map((item) => (item.rate === null || item.rate === undefined ? null : Number(item.rate) * 100)),
+    borderColor: CHART_COLORS.teal,
+    backgroundColor: 'rgba(15, 118, 110, 0.12)',
+    borderWidth: 2.5,
+    tension: 0.28,
+    // 空桶表示该时段没有终态历史，不应切断相邻真实历史点的趋势线。
+    spanGaps: true,
+    pointRadius: 3,
+    pointHoverRadius: 5,
+    pointHitRadius: 10,
+    fill: true,
+  };
+}
+
+export function createLineChartOptions(points) {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    layout: { padding: { top: 18, right: 16, bottom: 8, left: 4 } },
+    elements: { line: { spanGaps: true } },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => {
+            const point = points[ctx.dataIndex] || {};
+            return [
+              `成功率: ${percentLabel(point.rate)}`,
+              `success ${point.success || 0} / failed ${point.failed || 0} / skipped ${point.skipped || 0}`,
+              `pending ${point.pending || 0} / stopped ${point.stopped || 0}`,
+            ];
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        offset: true,
+        ticks: {
+          color: chartTextColor(),
+          maxRotation: 0,
+          autoSkip: true,
+          maxTicksLimit: 8,
+          padding: 8,
+        },
+        grid: { color: chartGridColor() },
+      },
+      y: {
+        min: 0,
+        suggestedMax: 100,
+        grace: '8%',
+        ticks: {
+          color: chartTextColor(),
+          callback: (value) => `${value}%`,
+          padding: 8,
+        },
+        grid: { color: chartGridColor() },
+      },
+    },
+  };
+}

--- a/pages/dashboard/store/modules/charts.js
+++ b/pages/dashboard/store/modules/charts.js
@@ -51,13 +51,12 @@ export function buildPushSuccessDataset(points) {
   };
 }
 
-export function createLineChartOptions(points) {
+export function createPushSuccessLineChartOptions(points) {
   return {
     responsive: true,
     maintainAspectRatio: false,
     interaction: { mode: 'index', intersect: false },
     layout: { padding: { top: 18, right: 16, bottom: 8, left: 4 } },
-    elements: { line: { spanGaps: true } },
     plugins: {
       legend: { display: false },
       tooltip: {

--- a/pages/dashboard/store/modules/overview.js
+++ b/pages/dashboard/store/modules/overview.js
@@ -1,14 +1,13 @@
 import { getDashboardCharts, getStats } from '../../js/api.js';
-
-const CHART_COLORS = {
-  orange: '#f59e0b',
-  red: '#ef4444',
-  amber: '#eab308',
-  teal: '#0f766e',
-  blue: '#2563eb',
-  slate: '#64748b',
-  green: '#16a34a',
-};
+import {
+  buildPushSuccessDataset,
+  CHART_COLORS,
+  chartGridColor,
+  chartTextColor,
+  createLineChartOptions,
+  formatBucketLabel,
+  percentLabel,
+} from './charts.js';
 
 const FEED_HEALTH_LABELS = {
   healthy: '健康',
@@ -71,28 +70,6 @@ const doughnutLabelPlugin = {
     ctx.restore();
   },
 };
-
-function chartTextColor() {
-  return document.documentElement.dataset.theme === 'dark' ? '#cbd5e1' : '#475569';
-}
-
-function chartGridColor() {
-  return document.documentElement.dataset.theme === 'dark' ? 'rgba(148, 163, 184, 0.22)' : 'rgba(148, 163, 184, 0.24)';
-}
-
-function formatBucketLabel(value, unit) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return String(value || '');
-  if (unit === 'hour') {
-    return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:00`;
-  }
-  return `${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
-}
-
-function percentLabel(value) {
-  if (value === null || value === undefined) return '无终态记录';
-  return `${Math.round(Number(value) * 1000) / 10}%`;
-}
 
 function destroyChart(instance) {
   if (!instance || typeof instance.destroy !== 'function') return;
@@ -158,25 +135,11 @@ export const overviewModule = {
     const data = this.overviewCharts.push_success || { points: [], unit: 'day' };
     const points = data.points || [];
     const labels = points.map((item) => formatBucketLabel(item.bucket, data.unit));
-    const rates = points.map((item) => (item.rate === null || item.rate === undefined ? null : Number(item.rate) * 100));
     chartInstances.pushSuccess = new ChartCtor(canvas, {
       type: 'line',
       data: {
         labels,
-        datasets: [
-          {
-            label: '推送成功率',
-            data: rates,
-            borderColor: CHART_COLORS.teal,
-            backgroundColor: 'rgba(15, 118, 110, 0.12)',
-            borderWidth: 2,
-            tension: 0.32,
-            spanGaps: false,
-            pointRadius: 2,
-            pointHoverRadius: 4,
-            fill: true,
-          },
-        ],
+        datasets: [buildPushSuccessDataset(points)],
       },
       options: this.lineChartOptions(points),
     });
@@ -229,30 +192,7 @@ export const overviewModule = {
   },
 
   lineChartOptions(points) {
-    return {
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: { mode: 'index', intersect: false },
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => {
-              const point = points[ctx.dataIndex] || {};
-              return [
-                `成功率: ${percentLabel(point.rate)}`,
-                `success ${point.success || 0} / failed ${point.failed || 0} / skipped ${point.skipped || 0}`,
-                `pending ${point.pending || 0} / stopped ${point.stopped || 0}`,
-              ];
-            },
-          },
-        },
-      },
-      scales: {
-        x: { ticks: { color: chartTextColor(), maxRotation: 0, autoSkip: true }, grid: { color: chartGridColor() } },
-        y: { min: 0, max: 100, ticks: { color: chartTextColor(), callback: (value) => `${value}%` }, grid: { color: chartGridColor() } },
-      },
-    };
+    return createLineChartOptions(points);
   },
 
   barChartOptions() {

--- a/pages/dashboard/store/modules/overview.js
+++ b/pages/dashboard/store/modules/overview.js
@@ -4,7 +4,7 @@ import {
   CHART_COLORS,
   chartGridColor,
   chartTextColor,
-  createLineChartOptions,
+  createPushSuccessLineChartOptions,
   formatBucketLabel,
   percentLabel,
 } from './charts.js';
@@ -192,7 +192,7 @@ export const overviewModule = {
   },
 
   lineChartOptions(points) {
-    return createLineChartOptions(points);
+    return createPushSuccessLineChartOptions(points);
   },
 
   barChartOptions() {

--- a/tests/frontend/overview-charts.test.mjs
+++ b/tests/frontend/overview-charts.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildPushSuccessDataset,
+  createLineChartOptions,
+  formatBucketLabel,
+} from '../../pages/dashboard/store/modules/charts.js';
+
+test('推送成功率折线图会连接有数据的历史节点', () => {
+  const points = [
+    { bucket: '2026-06-11T00:00:00Z', rate: 0.89 },
+    { bucket: '2026-06-12T00:00:00Z', rate: null },
+    { bucket: '2026-06-15T00:00:00Z', rate: 1 },
+    { bucket: '2026-06-16T00:00:00Z', rate: 0.94 },
+  ];
+
+  const dataset = buildPushSuccessDataset(points);
+  const options = createLineChartOptions(points);
+
+  assert.deepEqual(dataset.data, [89, null, 100, 94]);
+  assert.equal(dataset.spanGaps, true);
+  assert.equal(options.elements.line.spanGaps, true);
+});
+
+test('推送成功率折线图为坐标轴和顶部点保留舒展空间', () => {
+  const options = createLineChartOptions([]);
+
+  assert.deepEqual(options.layout.padding, { top: 18, right: 16, bottom: 8, left: 4 });
+  assert.equal(options.scales.y.suggestedMax, 100);
+  assert.equal(options.scales.y.grace, '8%');
+});
+
+test('时间桶标签按日展示，避免横轴过度拥挤', () => {
+  assert.equal(formatBucketLabel('2026-06-16T00:00:00Z', 'day'), '06/16');
+});

--- a/tests/frontend/overview-charts.test.mjs
+++ b/tests/frontend/overview-charts.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import {
   buildPushSuccessDataset,
-  createLineChartOptions,
+  createPushSuccessLineChartOptions,
   formatBucketLabel,
 } from '../../pages/dashboard/store/modules/charts.js';
 
@@ -16,19 +16,18 @@ test('推送成功率折线图会连接有数据的历史节点', () => {
   ];
 
   const dataset = buildPushSuccessDataset(points);
-  const options = createLineChartOptions(points);
 
   assert.deepEqual(dataset.data, [89, null, 100, 94]);
   assert.equal(dataset.spanGaps, true);
-  assert.equal(options.elements.line.spanGaps, true);
 });
 
 test('推送成功率折线图为坐标轴和顶部点保留舒展空间', () => {
-  const options = createLineChartOptions([]);
+  const options = createPushSuccessLineChartOptions([]);
 
   assert.deepEqual(options.layout.padding, { top: 18, right: 16, bottom: 8, left: 4 });
   assert.equal(options.scales.y.suggestedMax, 100);
   assert.equal(options.scales.y.grace, '8%');
+  assert.equal(options.elements?.line?.spanGaps, undefined);
 });
 
 test('时间桶标签按日展示，避免横轴过度拥挤', () => {


### PR DESCRIPTION
## Summary
- extract overview chart helpers for the push success line chart
- connect sparse historical success-rate points across empty buckets
- add chart padding and larger canvas space for a less cramped overview panel
- add Node regression tests for sparse history and chart spacing config

## Tests
- node --test tests/frontend/overview-charts.test.mjs
- tsc --noEmit --allowJs --checkJs false
- git diff --check

## Notes
- Full Python unit runner is blocked in this local environment by missing runtime deps (feedparser / astrbot), unrelated to this frontend-only change.

## Summary by Sourcery

优化仪表盘概览中的“推送成功率”折线图视觉效果和行为表现，同时将通用图表辅助方法集中管理以便复用。

Enhancements:
- 将共享的图表配置和辅助工具提取到一个专用的仪表盘图表模块中，便于统一管理和复用。
- 调整“推送成功率”折线图的样式和选项，更好地处理稀疏的历史数据，并在概览面板中提供更清晰的间距和内边距。
- 微调概览图表的布局和字体排版，为元数据和画布留出更多空间，并在不同屏幕尺寸上提升可读性。

Tests:
- 新增基于 Node 的前端回归测试，用于验证概览图表的行为，包括稀疏历史数据处理和间距配置等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the dashboard overview push success line chart visuals and behavior while centralizing shared chart helpers for reuse.

Enhancements:
- Extract shared chart configuration and helper utilities into a dedicated charts module for the dashboard.
- Adjust push success line chart styling and options to better handle sparse historical data and provide clearer spacing and padding in the overview panel.
- Tweak overview chart layout and typography to give metadata and canvases more space and improve readability across screen sizes.

Tests:
- Add frontend Node-based regression tests for overview chart behavior, including sparse history handling and spacing configuration.

</details>