### PR TITLE
fix: remove redundant filter search buttons

### DIFF
--- a/pages/dashboard/components/shared/filters.js
+++ b/pages/dashboard/components/shared/filters.js
@@ -73,7 +73,6 @@ export function compactFilterToolbarTemplate({
         </select>
         ${compactFilterInput(groupName, activeFieldExpr)}
         <button class="btn btn-add-circle" type="button" title="添加筛选条件" aria-label="添加筛选条件" @click="addCompactFilterCondition('${groupName}')">+</button>
-        <button class="btn btn-primary compact-search-button" type="button" :class="{ 'is-loading': isPending('${pendingKey}') }" :disabled="isPending('${pendingKey}')" @click="runPending('${pendingKey}', () => ${loadAction})"><span aria-hidden="true">⌕</span><span>搜索</span></button>
         <button class="btn btn-secondary compact-clear-button" v-if="${hasFilters}()" type="button" :disabled="isPending('${pendingKey}')" @click="${clearAction}()">清空</button>
         <div class="compact-toolbar-spacer"></div>
         ${extraButtons.join('\n        ')}

--- a/pages/dashboard/css/dashboard.css
+++ b/pages/dashboard/css/dashboard.css
@@ -88,7 +88,6 @@
 .compact-filter-funnel { flex: 0 0 auto; position: static; transform: none; color: #64748b; }
 .compact-filter-field { flex: 0 0 150px; min-width: 130px; }
 .compact-filter-value { flex: 1 1 190px; min-width: 160px; max-width: 280px; }
-.compact-search-button { min-width: 90px; }
 .compact-clear-button { min-width: 72px; }
 .compact-toolbar-spacer { flex: 1 1 40px; min-width: 0; }
 .compact-filter-row > .btn-icon { flex: 0 0 40px; }
@@ -296,12 +295,10 @@ textarea.select-input { resize: vertical; line-height: 1.5; }
   .compact-filter-funnel,
   .compact-filter-field,
   .compact-filter-value,
-  .compact-search-button,
   .compact-clear-button,
   .compact-filter-row > .btn:not(.btn-icon) { grid-column: 1 / -1; width: 100%; }
   .compact-filter-row > .btn-add-circle { grid-column: 1; width: 40px; justify-self: start; }
   .compact-filter-row > .btn-icon { grid-column: 2; grid-row: auto; justify-self: end; }
-  .compact-search-button { min-width: 0; }
   .compact-filter-chips { gap: 6px; }
   .filter-chip { max-width: 100%; }
   .dashboard-content { min-height: auto; display: block; overflow: visible; padding-bottom: 0; scrollbar-gutter: auto; }


### PR DESCRIPTION
## Summary
- remove the redundant Search button from the shared compact filter toolbar
- keep refresh, clear, Enter-to-search, and add-filter-condition interactions intact
- remove the now-unused compact-search-button CSS

## Tests
- tsc --noEmit --allowJs --checkJs false
- node --test tests/frontend/overview-charts.test.mjs
- git diff --check origin/dev..HEAD

## Summary by Sourcery

从紧凑筛选工具栏中移除多余的搜索按钮，并清理其未使用的样式。

增强内容：
- 简化紧凑筛选工具栏，依靠现有交互（刷新、清除、回车搜索、添加条件），而不再使用单独的搜索按钮。
- 从仪表盘样式表中移除与紧凑搜索按钮相关的未使用 CSS 规则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the redundant search button from the compact filter toolbar and clean up its unused styles.

Enhancements:
- Simplify the compact filter toolbar by relying on existing interactions (refresh, clear, enter-to-search, add-condition) without a dedicated search button.
- Remove unused CSS rules related to the compact search button in the dashboard stylesheet.

</details>